### PR TITLE
[Feat] Network Service

### DIFF
--- a/MovieExplorer/MovieExplorer/Data/Network/APIEndpoint.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/APIEndpoint.swift
@@ -17,5 +17,6 @@ protocol APIEndpoint {
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: [String: String]? { get }
-    var parameters: [String: Any]? { get }
+    var queryParameters: [String: Any]? { get }
+    var bodyParameters: [String: Any]? { get }
 }

--- a/MovieExplorer/MovieExplorer/Data/Network/APIEndpoint.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/APIEndpoint.swift
@@ -18,5 +18,5 @@ protocol APIEndpoint {
     var method: HTTPMethod { get }
     var headers: [String: String]? { get }
     var queryParameters: [String: Any]? { get }
-    var bodyParameters: [String: Any]? { get }
+    var bodyParameters: Encodable? { get }
 }

--- a/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
@@ -60,7 +60,7 @@ enum MovieEndpoint: APIEndpoint {
         }
     }
 
-    var bodyParameters: [String: Any]? {
+    var bodyParameters: Encodable? {
         return nil
     }
 }

--- a/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
@@ -40,7 +40,7 @@ enum MovieEndpoint: APIEndpoint {
         ]
     }
 
-    var parameters: [String: Any]? {
+    var queryParameters: [String: Any]? {
         switch self {
         case .popular(let page):
             return [
@@ -58,5 +58,9 @@ enum MovieEndpoint: APIEndpoint {
                 "language": "ko-KR"
             ]
         }
+    }
+
+    var bodyParameters: [String: Any]? {
+        return nil
     }
 }

--- a/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
@@ -6,6 +6,13 @@
 
 import Foundation
 
+private struct AnyEncodable: Encodable {
+    let value: Encodable
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
 final class NetworkService: NetworkServiceProtocol {
 
     private let session: URLSession
@@ -15,6 +22,53 @@ final class NetworkService: NetworkServiceProtocol {
     }
 
     func request<T: Decodable>(endpoint: APIEndpoint) async throws -> T {
-        fatalError("Not implemented yet")
+
+        guard let baseURL = URL(string: endpoint.baseURL) else {
+            throw NetworkError.invalidURL
+        }
+        
+        let path = endpoint.path.hasPrefix("/") ? String(endpoint.path.dropFirst()) : endpoint.path
+        let fullURL = baseURL.appendingPathComponent(path)
+        
+        guard var components = URLComponents(url: fullURL, resolvingAgainstBaseURL: true) else {
+            throw NetworkError.invalidURL
+        }
+
+        if let queryParameters = endpoint.queryParameters, !queryParameters.isEmpty {
+            components.queryItems = queryParameters.map { key, value in
+                URLQueryItem(name: key, value: "\(value)")
+            }
+        }
+        
+        guard let url = components.url else {
+            throw NetworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+
+        endpoint.headers?.forEach { key, value in
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        if let bodyParameters = endpoint.bodyParameters {
+            request.httpBody = try JSONEncoder().encode(AnyEncodable(value: bodyParameters))
+            if request.value(forHTTPHeaderField: "Content-Type") == nil {
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            }
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidURL
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw NetworkError.httpError(statusCode: httpResponse.statusCode)
+        }
+
+        let decodedData = try JSONDecoder().decode(T.self, from: data)
+        return decodedData
     }
 }

--- a/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
@@ -6,13 +6,6 @@
 
 import Foundation
 
-private struct AnyEncodable: Encodable {
-    let value: Encodable
-    func encode(to encoder: Encoder) throws {
-        try value.encode(to: encoder)
-    }
-}
-
 final class NetworkService: NetworkServiceProtocol {
 
     private let session: URLSession
@@ -52,7 +45,7 @@ final class NetworkService: NetworkServiceProtocol {
         }
 
         if let bodyParameters = endpoint.bodyParameters {
-            request.httpBody = try JSONEncoder().encode(AnyEncodable(value: bodyParameters))
+            request.httpBody = try JSONEncoder().encode(bodyParameters)
             if request.value(forHTTPHeaderField: "Content-Type") == nil {
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             }

--- a/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/NetworkService.swift
@@ -1,0 +1,20 @@
+//
+//  NetworkService.swift
+//  MovieExplorer
+//
+//
+
+import Foundation
+
+final class NetworkService: NetworkServiceProtocol {
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func request<T: Decodable>(endpoint: APIEndpoint) async throws -> T {
+        fatalError("Not implemented yet")
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Data/NetworkServiceTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/NetworkServiceTests.swift
@@ -29,6 +29,10 @@ final class NetworkServiceTests: XCTestCase {
     }
 
     func test_request가_URLRequest를_정확히_생성한다() async throws {
+        struct MockBody: Encodable {
+            let key: String
+        }
+        
         // Given
         let endpoint = MockEndpoint(
             baseURL: "https://api.test.com",
@@ -36,7 +40,7 @@ final class NetworkServiceTests: XCTestCase {
             method: .post,
             headers: ["Authorization": "Bearer Token"],
             queryParameters: ["query": "test"],
-            bodyParameters: ["key": "value"]
+            bodyParameters: MockBody(key: "value")
         )
         
         var capturedRequest: URLRequest?
@@ -70,12 +74,31 @@ final class NetworkServiceTests: XCTestCase {
         XCTAssertEqual(capturedRequest?.httpMethod, "POST")
         XCTAssertEqual(capturedRequest?.allHTTPHeaderFields?["Authorization"], "Bearer Token")
         
-        // Body 검증
-        if let httpBody = capturedRequest?.httpBody,
-           let jsonObject = try JSONSerialization.jsonObject(with: httpBody, options: []) as? [String: String] {
+        // Body 검증 
+        let httpBody: Data? = {
+            if let body = capturedRequest?.httpBody {
+                return body
+            }
+            guard let stream = capturedRequest?.httpBodyStream else {
+                return nil
+            }
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while stream.hasBytesAvailable {
+                let length = stream.read(&buffer, maxLength: buffer.count)
+                if length == 0 { break }
+                data.append(buffer, count: length)
+            }
+            return data
+        }()
+        
+        if let bodyData = httpBody,
+           let jsonObject = try JSONSerialization.jsonObject(with: bodyData, options: []) as? [String: String] {
             XCTAssertEqual(jsonObject["key"], "value")
         } else {
-            XCTFail("Body parameters가 잘못 설정되었습니다.")
+            XCTFail("Body parameters가 잘못 설정되었거나 추출에 실패했습니다.")
         }
     }
 
@@ -155,5 +178,5 @@ struct MockEndpoint: APIEndpoint {
     var method: HTTPMethod = .get
     var headers: [String: String]? = nil
     var queryParameters: [String: Any]? = nil
-    var bodyParameters: [String: Any]? = nil
+    var bodyParameters: Encodable? = nil
 }

--- a/MovieExplorer/MovieExplorerTests/Data/NetworkServiceTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/NetworkServiceTests.swift
@@ -1,0 +1,159 @@
+//
+//  NetworkServiceTests.swift
+//  MovieExplorerTests
+//
+
+import XCTest
+@testable import MovieExplorer
+
+final class NetworkServiceTests: XCTestCase {
+
+    var sut: NetworkService!
+    var mockSession: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: configuration)
+        
+        sut = NetworkService(session: mockSession)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockSession = nil
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func test_request가_URLRequest를_정확히_생성한다() async throws {
+        // Given
+        let endpoint = MockEndpoint(
+            baseURL: "https://api.test.com",
+            path: "/v1/data",
+            method: .post,
+            headers: ["Authorization": "Bearer Token"],
+            queryParameters: ["query": "test"],
+            bodyParameters: ["key": "value"]
+        )
+        
+        var capturedRequest: URLRequest?
+        let mockData = try JSONEncoder().encode(MockModel(id: 1, name: "Test"))
+        
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, mockData)
+        }
+        
+        // When
+        let _: MockModel? = try? await sut.request(endpoint: endpoint)
+        
+        // Then
+        XCTAssertNotNil(capturedRequest, "URLRequest가 캡처되지 않았습니다.")
+        
+        // URL 검증
+        XCTAssertTrue(capturedRequest?.url?.absoluteString.starts(with: "https://api.test.com/v1/data") ?? false)
+        
+        // Query Parameters 검증
+        if let url = capturedRequest?.url,
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+           let queryItems = components.queryItems {
+            XCTAssertTrue(queryItems.contains(URLQueryItem(name: "query", value: "test")))
+        } else {
+            XCTFail("Query parameters가 설정되지 않았습니다.")
+        }
+        
+        // Method 및 Headers 검증
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(capturedRequest?.allHTTPHeaderFields?["Authorization"], "Bearer Token")
+        
+        // Body 검증
+        if let httpBody = capturedRequest?.httpBody,
+           let jsonObject = try JSONSerialization.jsonObject(with: httpBody, options: []) as? [String: String] {
+            XCTAssertEqual(jsonObject["key"], "value")
+        } else {
+            XCTFail("Body parameters가 잘못 설정되었습니다.")
+        }
+    }
+
+    func test_request가_InvlaidStatusCode를_처리() async {
+        // Given
+        let endpoint = MockEndpoint(path: "/error")
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+            return (response, nil)
+        }
+        
+        // When & Then
+        do {
+            let _: MockModel = try await sut.request(endpoint: endpoint)
+            XCTFail("에러가 발생해야 하지만 성공했습니다.")
+        } catch let error as NetworkError {
+            guard case .httpError(let statusCode) = error else {
+                XCTFail("잘못된 에러가 발생했습니다: \(error)")
+                return
+            }
+            XCTAssertEqual(statusCode, 404)
+        } catch {
+            XCTFail("예상치 못한 에러.")
+        }
+    }
+
+    func test_request가_URLError_를_처리() async {
+        // Given
+        let endpoint = MockEndpoint(path: "/network-error")
+        let expectedError = URLError(.notConnectedToInternet)
+        
+        MockURLProtocol.requestHandler = { _ in
+            throw expectedError
+        }
+        
+        // When & Then
+        do {
+            let _: MockModel = try await sut.request(endpoint: endpoint)
+            XCTFail("네트워크 에러가 발생해야 하지만 성공했습니다.")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .notConnectedToInternet)
+        } catch {
+            XCTFail("URLError가 아닌 다른 에러가 발생했습니다: \(error)")
+        }
+    }
+
+    func test_request_JSON_데이터를_디코딩해_반환() async throws {
+        // Given
+        let endpoint = MockEndpoint(path: "/success")
+        let expectedModel = MockModel(id: 777, name: "Success Data")
+        let responseData = try JSONEncoder().encode(expectedModel)
+        
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, responseData)
+        }
+        
+        // When
+        let result: MockModel = try await sut.request(endpoint: endpoint)
+        
+        // Then
+        XCTAssertEqual(result.id, expectedModel.id)
+        XCTAssertEqual(result.name, expectedModel.name)
+    }
+}
+
+// MARK: - Mocks for Testing
+
+struct MockModel: Codable, Equatable {
+    let id: Int
+    let name: String
+}
+
+struct MockEndpoint: APIEndpoint {
+    var baseURL: String = "https://mock.com"
+    var path: String = "/mock"
+    var method: HTTPMethod = .get
+    var headers: [String: String]? = nil
+    var queryParameters: [String: Any]? = nil
+    var bodyParameters: [String: Any]? = nil
+}

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockURLProtocol.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockURLProtocol.swift
@@ -1,0 +1,39 @@
+//
+//  MockURLProtocol.swift
+//  MovieExplorerTests
+//
+
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("MockURLProtocol.requestHandler is not set.")
+        }
+        
+        do {
+            let (response, data) = try handler(request)
+
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+    
+    override func stopLoading() {}
+}


### PR DESCRIPTION
### APIEndpoint 변경
- queryParameter 와 bodyParameter를 구분해 받음
- bodyParameter는 encodable로 받음.

### NetworkService
- URL.appendingPathComponent: 슬래시 중복 방지
- Content-Type: application/json
- 상태 코드에 따른 에러처리

### 테스트
- URLRequest의 쿼리, 메소드, 헤더, body를 점검.
- 단 body는 URLProtocol로 가로챘을 때 nil로 나타나 httpBodyStream 객체를 읽어오도록 함.
- 상태 코드 에러 검증
- 네트워크 에러 검증
- 디코딩 성공 검증