### PR TITLE
[Feat] movie detail view

### DIFF
--- a/MovieExplorer/MovieExplorer/Data/DTOs/MovieDetailResponseDTO.swift
+++ b/MovieExplorer/MovieExplorer/Data/DTOs/MovieDetailResponseDTO.swift
@@ -32,7 +32,7 @@ struct MovieDetailResponseDTO: Decodable {
             title: title,
             overview: overview,
             posterPath: ImageURLMapper.makeFullPath(imagePath: posterPath),
-            backdropPath: ImageURLMapper.makeFullPath(imagePath: backdropPath),
+            backdropPath: ImageURLMapper.makeFullPath(imagePath: backdropPath, type: .backdrop),
             releaseDate: releaseDate,
             runtime: runtime,
             genres: genres.map { $0.name },

--- a/MovieExplorer/MovieExplorer/Data/Network/ImageURLMapper.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/ImageURLMapper.swift
@@ -9,17 +9,26 @@ import Foundation
 import UIKit
 
 enum ImageURLMapper {
-    static let baseURL = "https://image.tmdb.org/t/p/"
-    static let size: String = {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            "w780"
-        } else {
-            "w500"
-        }
-    }()
+    enum ImageType {
+        case poster
+        case backdrop
+    }
 
-    static func makeFullPath(imagePath: String?) -> URL? {
+    static let baseURL = "https://image.tmdb.org/t/p/"
+    static let sizeForPoster: String = UIDevice.current.userInterfaceIdiom == .pad ? "w780" : "w500"
+    static let sizeForBackdrop: String = UIDevice.current.userInterfaceIdiom == .pad ? "original" : "w1280"
+
+    static func makeFullPath(imagePath: String?, type: ImageType = .poster) -> URL? {
         guard let imagePath, !imagePath.isEmpty else { return nil }
+
+        let size: String
+        switch type {
+        case .poster:
+            size = sizeForPoster
+        case .backdrop:
+            size = sizeForBackdrop
+        }
+
         return URL(string: baseURL)?
             .appendingPathComponent(size)
             .appendingPathComponent(imagePath)

--- a/MovieExplorer/MovieExplorer/Domain/UseCases/GetMovieDetailUseCase.swift
+++ b/MovieExplorer/MovieExplorer/Domain/UseCases/GetMovieDetailUseCase.swift
@@ -1,0 +1,19 @@
+//
+//  GetMovieDetailUseCase.swift
+//  MovieExplorer
+//
+//  Created by Liam on 5/7/26.
+//
+
+protocol GetMovieDetailUseCase {
+    func execute(id: Int) async throws -> MovieDetail
+}
+
+struct DefaultGetMovieDetailUseCase: GetMovieDetailUseCase {
+
+    let movieRepository: MovieRepositoryProtocol
+
+    func execute(id: Int) async throws -> MovieDetail {
+        try await movieRepository.fetchMovieDetail(id: id)
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/GenreTagView.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/GenreTagView.swift
@@ -1,0 +1,142 @@
+//
+//  GenreTagView.swift
+//  MovieExplorer
+//
+
+import UIKit
+import SnapKit
+
+final class GenreTagCell: UICollectionViewCell {
+    static let identifier = "GenreTagCell"
+    
+    private let tagImageView: UIImageView = {
+        let iv = UIImageView(image: UIImage(systemName: "tag.fill"))
+        iv.tintColor = .secondaryLabel
+        iv.contentMode = .scaleAspectFit
+        return iv
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+    
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.alignment = .center
+        return stack
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = .systemGray6
+        contentView.layer.cornerRadius = 6
+
+        contentView.addSubview(stackView)
+        stackView.addArrangedSubview(tagImageView)
+        stackView.addArrangedSubview(titleLabel)
+
+        tagImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(12)
+        }
+
+        stackView.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(6)
+            make.leading.trailing.equalToSuperview().inset(8)
+        }
+    }
+
+    func configure(with text: String) {
+        titleLabel.text = text
+    }
+}
+
+final class GenreTagView: UIView {
+
+    private var genres: [String] = []
+
+    private lazy var collectionView: UICollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        cv.backgroundColor = .clear
+        cv.isScrollEnabled = false
+        cv.register(GenreTagCell.self, forCellWithReuseIdentifier: GenreTagCell.identifier)
+        cv.dataSource = self
+        return cv
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupUI() {
+        addSubview(collectionView)
+        collectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.height.equalTo(1)
+        }
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .estimated(60),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(28)
+        )
+
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(8)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+
+    func configure(genres: [String]) {
+        self.genres = genres
+        collectionView.reloadData()
+
+        DispatchQueue.main.async {
+            self.collectionView.snp.updateConstraints { make in
+                make.height.equalTo(self.collectionView.contentSize.height)
+            }
+        }
+    }
+}
+
+extension GenreTagView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return genres.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GenreTagCell.identifier, for: indexPath) as? GenreTagCell else {
+            return UICollectionViewCell()
+        }
+        cell.configure(with: genres[indexPath.item])
+        return cell
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -190,7 +190,8 @@ final class MovieDetailViewController: UIViewController {
         titleInfoView.configure(
             title: movie.title,
             voteAverageText: viewModel.voteAverageText,
-            releaseDateText: viewModel.releaseDateText
+            releaseDateText: viewModel.releaseDateText,
+            genres: movie.genres
         )
 
         if let url = viewModel.movieDetail?.backdropPath {
@@ -245,7 +246,7 @@ struct MovieDetailPreview: PreviewProvider {
         let networkService = NetworkService()
         let repository = DefaultMovieRepository(networkService: networkService)
         let useCase = DefaultGetMovieDetailUseCase(movieRepository: repository)
-        let viewModel = MovieDetailViewModel(movieId: 12, getMovieDetailUseCase: useCase)
+        let viewModel = MovieDetailViewModel(movieId: 502356, getMovieDetailUseCase: useCase)
         let vc = MovieDetailViewController(viewModel: viewModel)
         return UINavigationController(rootViewController: vc)
     }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -37,18 +37,12 @@ final class MovieDetailViewController: UIViewController {
         return iv
     }()
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .title3)
-        label.numberOfLines = 2
-        return label
-    }()
-    
-    private let infoStackView: UIStackView = {
+    private let titleInfoView = MovieTitleInfoView()
+
+    private let tagView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
         stack.spacing = 12
-        stack.alignment = .center
         return stack
     }()
 
@@ -110,8 +104,7 @@ final class MovieDetailViewController: UIViewController {
         view.addSubview(loadingIndicator)
 
         contentView.addSubview(posterImageView)
-        contentView.addSubview(titleLabel)
-        contentView.addSubview(infoStackView)
+        contentView.addSubview(titleInfoView)
         contentView.addSubview(overviewHeaderLabel)
         contentView.addSubview(overviewLabel)
 
@@ -144,15 +137,10 @@ final class MovieDetailViewController: UIViewController {
             make.width.equalTo(posterImageView.snp.height).multipliedBy(2.0 / 3.0)
         }
 
-        titleLabel.snp.makeConstraints { make in
+        titleInfoView.snp.makeConstraints { make in
             make.top.equalTo(posterImageView.snp.top).inset(8)
             make.leading.equalTo(posterImageView.snp.trailing).offset(15)
             make.trailing.equalToSuperview().inset(20)
-        }
-
-        infoStackView.snp.makeConstraints { make in
-            make.leading.equalTo(titleLabel)
-            make.top.equalTo(titleLabel.snp.bottom).offset(8)
         }
 
         overviewHeaderLabel.snp.makeConstraints { make in
@@ -197,10 +185,13 @@ final class MovieDetailViewController: UIViewController {
     
     private func updateUI() {
         guard let movie = viewModel.movieDetail else { return }
-        titleLabel.text = movie.title
         overviewLabel.text = movie.overview
-
-        setInfoLabel()
+        
+        titleInfoView.configure(
+            title: movie.title,
+            voteAverageText: viewModel.voteAverageText,
+            releaseDateText: viewModel.releaseDateText
+        )
 
         if let url = viewModel.movieDetail?.backdropPath {
             backdropImageView.kf.setImage(with: url, options: [.transition(.fade(0.3))])
@@ -208,28 +199,6 @@ final class MovieDetailViewController: UIViewController {
         if let url = viewModel.movieDetail?.posterPath {
             posterImageView.kf.setImage(with: url)
         }
-    }
-
-    private func setInfoLabel() {
-        infoStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-
-        let ratingLabel = UILabel()
-        ratingLabel.text = viewModel.voteAverageText
-
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.spacing = 4
-        if let date = viewModel.releaseDateText {
-            let calendarImage = UIImageView(image: UIImage(systemName: "calendar"))
-            calendarImage.tintColor = .gray
-            let dateLabel = UILabel()
-            dateLabel.text = date
-            stackView.addArrangedSubview(calendarImage)
-            stackView.addArrangedSubview(dateLabel)
-        }
-
-        infoStackView.addArrangedSubview(ratingLabel)
-        infoStackView.addArrangedSubview(stackView)
     }
 
     private func showError(_ message: String) {

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -1,0 +1,256 @@
+//
+//  MovieDetailViewController.swift
+//  MovieExplorer
+//
+//
+
+import UIKit
+import Combine
+import SnapKit
+import Kingfisher
+
+final class MovieDetailViewController: UIViewController {
+    
+    private let viewModel: MovieDetailViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    
+    private let backdropImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.backgroundColor = .systemGray5
+        return iv
+    }()
+
+    private let gradientView = UIView()
+    private let gradientLayer = CAGradientLayer()
+
+    private let posterImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.layer.cornerRadius = 8
+        iv.clipsToBounds = true
+        iv.backgroundColor = .gray
+        return iv
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title3)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private let infoStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        return stack
+    }()
+
+    private let overviewHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "줄거리"
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        return label
+    }()
+
+    private let overviewLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+    
+    init(viewModel: MovieDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        bindViewModel()
+        
+        Task {
+            await viewModel.fetchDetail()
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        gradientLayer.frame = gradientView.bounds
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        navigationController?.setNavigationBarHidden(false, animated: true)
+
+        view.addSubview(backdropImageView)
+        view.addSubview(gradientView)
+        applyGradient()
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        view.addSubview(loadingIndicator)
+        
+        contentView.addSubview(posterImageView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(infoStackView)
+        contentView.addSubview(overviewHeaderLabel)
+        contentView.addSubview(overviewLabel)
+
+        backdropImageView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(backdropImageView.snp.width).multipliedBy(9.0 / 16.0)
+        }
+
+        gradientView.snp.makeConstraints { make in
+            make.edges.equalTo(backdropImageView)
+        }
+
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalTo(scrollView.contentLayoutGuide)
+            make.width.equalTo(scrollView.frameLayoutGuide)
+        }
+
+        loadingIndicator.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        posterImageView.snp.makeConstraints { make in
+            make.top.equalTo(backdropImageView.snp.centerY)
+            make.bottom.equalTo(backdropImageView.snp.bottom)
+            make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
+            make.width.equalTo(posterImageView.snp.height).multipliedBy(2.0 / 3.0)
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(posterImageView.snp.top).inset(8)
+            make.leading.equalTo(posterImageView.snp.trailing).offset(15)
+            make.trailing.equalToSuperview().inset(20)
+        }
+
+        overviewHeaderLabel.snp.makeConstraints { make in
+            make.top.equalTo(posterImageView.snp.bottom).offset(40)
+            make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
+        }
+
+        overviewLabel.snp.makeConstraints { make in
+            make.top.equalTo(overviewHeaderLabel.snp.bottom).offset(12)
+            make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
+            make.trailing.equalToSuperview().inset(20)
+        }
+    }
+
+    private func applyGradient() {
+        gradientLayer.colors = [UIColor.clear.cgColor, UIColor.black.cgColor]
+        gradientLayer.locations = [0.0, 0.9]
+        gradientView.layer.addSublayer(gradientLayer)
+    }
+
+    private func bindViewModel() {
+        viewModel.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                switch state {
+                case .loading:
+                    self?.loadingIndicator.startAnimating()
+                    self?.scrollView.isHidden = true
+                case .loaded:
+                    self?.loadingIndicator.stopAnimating()
+                    self?.scrollView.isHidden = false
+                    self?.updateUI()
+                case .error(let message):
+                    self?.loadingIndicator.stopAnimating()
+                    self?.showError(message)
+                case .idle:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateUI() {
+        guard let movie = viewModel.movieDetail else { return }
+        titleLabel.text = movie.title
+        overviewLabel.text = movie.overview
+
+
+        if let url = viewModel.movieDetail?.backdropPath {
+            backdropImageView.kf.setImage(with: url, options: [.transition(.fade(0.3))])
+        }
+        if let url = viewModel.movieDetail?.posterPath {
+            posterImageView.kf.setImage(with: url)
+        }
+    }
+    
+    private func showError(_ message: String) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+#if DEBUG
+import SwiftUI
+
+struct MovieDetailPreview: PreviewProvider {
+
+    static var previews: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 60) {
+                VStack {
+                    Text("iPhone 17 Pro").font(.headline).foregroundColor(.gray)
+                    UIViewControllerPreview {
+                        makeViewController(movieId: 12)
+                    }
+                    .frame(width: 402, height: 874)
+                    .border(Color.gray.opacity(0.5), width: 2)
+                    .clipped()
+                }
+
+                VStack {
+                    Text("iPad Pro 13-inch").font(.headline).foregroundColor(.gray)
+                    UIViewControllerPreview {
+                        makeViewController(movieId: 12)
+                    }
+                    .frame(width: 1032, height: 1376)
+                    .border(Color.gray.opacity(0.5), width: 2)
+                    .clipped()
+                }
+            }
+            .padding(40)
+        }
+        .previewLayout(.sizeThatFits)
+    }
+
+    static func makeViewController(movieId: Int) -> UIViewController {
+        let networkService = NetworkService()
+        let repository = DefaultMovieRepository(networkService: networkService)
+        let useCase = DefaultGetMovieDetailUseCase(movieRepository: repository)
+        let viewModel = MovieDetailViewModel(movieId: 12, getMovieDetailUseCase: useCase)
+        let vc = MovieDetailViewController(viewModel: viewModel)
+        return UINavigationController(rootViewController: vc)
+    }
+}
+#endif

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -108,7 +108,7 @@ final class MovieDetailViewController: UIViewController {
         scrollView.addSubview(contentView)
 
         view.addSubview(loadingIndicator)
-        
+
         contentView.addSubview(posterImageView)
         contentView.addSubview(titleLabel)
         contentView.addSubview(infoStackView)
@@ -148,6 +148,11 @@ final class MovieDetailViewController: UIViewController {
             make.top.equalTo(posterImageView.snp.top).inset(8)
             make.leading.equalTo(posterImageView.snp.trailing).offset(15)
             make.trailing.equalToSuperview().inset(20)
+        }
+
+        infoStackView.snp.makeConstraints { make in
+            make.leading.equalTo(titleLabel)
+            make.top.equalTo(titleLabel.snp.bottom).offset(8)
         }
 
         overviewHeaderLabel.snp.makeConstraints { make in
@@ -195,6 +200,7 @@ final class MovieDetailViewController: UIViewController {
         titleLabel.text = movie.title
         overviewLabel.text = movie.overview
 
+        setInfoLabel()
 
         if let url = viewModel.movieDetail?.backdropPath {
             backdropImageView.kf.setImage(with: url, options: [.transition(.fade(0.3))])
@@ -203,7 +209,29 @@ final class MovieDetailViewController: UIViewController {
             posterImageView.kf.setImage(with: url)
         }
     }
-    
+
+    private func setInfoLabel() {
+        infoStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        let ratingLabel = UILabel()
+        ratingLabel.text = viewModel.voteAverageText
+
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 4
+        if let date = viewModel.releaseDateText {
+            let calendarImage = UIImageView(image: UIImage(systemName: "calendar"))
+            calendarImage.tintColor = .gray
+            let dateLabel = UILabel()
+            dateLabel.text = date
+            stackView.addArrangedSubview(calendarImage)
+            stackView.addArrangedSubview(dateLabel)
+        }
+
+        infoStackView.addArrangedSubview(ratingLabel)
+        infoStackView.addArrangedSubview(stackView)
+    }
+
     private func showError(_ message: String) {
         let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default))

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -152,6 +152,7 @@ final class MovieDetailViewController: UIViewController {
             make.top.equalTo(overviewHeaderLabel.snp.bottom).offset(12)
             make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
             make.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(24)
         }
     }
 

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -32,18 +32,7 @@ final class MovieDetailViewModel {
             let result = try await getMovieDetailUseCase.execute(id: movieId)
             movieDetail = result
         } catch let error as MovieError {
-            switch error {
-            case .networkFailure:
-                errorMessage = "네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요."
-            case .serverError:
-                errorMessage = "서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
-            case .invalidRequest:
-                errorMessage = "잘못된 요청입니다."
-            case .decodingFailure:
-                errorMessage = "데이터를 불러오는 중 오류가 발생했습니다."
-            case .unknown:
-                errorMessage = "알 수 없는 오류가 발생했습니다."
-            }
+            errorMessage = error.description
         } catch {
             errorMessage = "예기치 못한 오류가 발생했습니다: \(error.localizedDescription)"
         }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -48,8 +48,10 @@ final class MovieDetailViewModel {
             movieDetail = result
             state = .loaded
         } catch let error as MovieError {
+            movieDetail = nil
             state = .error(error.description)
         } catch {
+            movieDetail = nil
             state = .error("예기치 못한 오류가 발생했습니다: \(error.localizedDescription)")
         }
     }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  MovieDetailViewModel.swift
+//  MovieExplorer
+//
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class MovieDetailViewModel {
+    
+    @Published private(set) var movieDetail: MovieDetail?
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var errorMessage: String? = nil
+    
+    private let movieId: Int
+    private let getMovieDetailUseCase: GetMovieDetailUseCase
+    
+    init(movieId: Int, getMovieDetailUseCase: GetMovieDetailUseCase) {
+        self.movieId = movieId
+        self.getMovieDetailUseCase = getMovieDetailUseCase
+    }
+    
+    func fetchDetail() async {
+        guard !isLoading else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let result = try await getMovieDetailUseCase.execute(id: movieId)
+            movieDetail = result
+        } catch let error as MovieError {
+            switch error {
+            case .networkFailure:
+                errorMessage = "네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요."
+            case .serverError:
+                errorMessage = "서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+            case .invalidRequest:
+                errorMessage = "잘못된 요청입니다."
+            case .decodingFailure:
+                errorMessage = "데이터를 불러오는 중 오류가 발생했습니다."
+            case .unknown:
+                errorMessage = "알 수 없는 오류가 발생했습니다."
+            }
+        } catch {
+            errorMessage = "예기치 못한 오류가 발생했습니다: \(error.localizedDescription)"
+        }
+        
+        isLoading = false
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -20,6 +20,10 @@ final class MovieDetailViewModel {
     @Published private(set) var state: DetailViewState = .idle
     
     private(set) var movieDetail: MovieDetail?
+    var voteAverageText: String? {
+        guard let voteAverage = movieDetail?.voteAverage else { return nil }
+        return "⭐ " + voteAverage.description
+    }
     var releaseDateText: String? {
         guard let dateString = movieDetail?.releaseDate, !dateString.isEmpty else {
             return nil

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -7,13 +7,26 @@
 import Foundation
 import Combine
 
+enum DetailViewState: Equatable {
+    case idle
+    case loading
+    case loaded
+    case error(String)
+}
+
 @MainActor
 final class MovieDetailViewModel {
     
-    @Published private(set) var movieDetail: MovieDetail?
-    @Published private(set) var isLoading: Bool = false
-    @Published private(set) var errorMessage: String? = nil
+    @Published private(set) var state: DetailViewState = .idle
     
+    private(set) var movieDetail: MovieDetail?
+    var releaseDateText: String? {
+        guard let dateString = movieDetail?.releaseDate, !dateString.isEmpty else {
+            return nil
+        }
+        return dateString.replacingOccurrences(of: "-", with: ".")
+    }
+
     private let movieId: Int
     private let getMovieDetailUseCase: GetMovieDetailUseCase
     
@@ -23,20 +36,17 @@ final class MovieDetailViewModel {
     }
     
     func fetchDetail() async {
-        guard !isLoading else { return }
-        
-        isLoading = true
-        errorMessage = nil
+        if state == .loading { return }
+        state = .loading
         
         do {
             let result = try await getMovieDetailUseCase.execute(id: movieId)
             movieDetail = result
+            state = .loaded
         } catch let error as MovieError {
-            errorMessage = error.description
+            state = .error(error.description)
         } catch {
-            errorMessage = "예기치 못한 오류가 발생했습니다: \(error.localizedDescription)"
+            state = .error("예기치 못한 오류가 발생했습니다: \(error.localizedDescription)")
         }
-        
-        isLoading = false
     }
 }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
@@ -46,23 +46,7 @@ final class MovieTitleInfoView: UIView {
         return label
     }()
     
-    private let genreStackView: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.spacing = 4
-        return stack
-    }()
-    
-    private let tagImageView: UIImageView = {
-        let iv = UIImageView(image: UIImage(systemName: "tag"))
-        iv.tintColor = .gray
-        return iv
-    }()
-    
-    private let genreLabel: UILabel = {
-        let label = UILabel()
-        return label
-    }()
+    private let genreTagView = GenreTagView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -76,7 +60,7 @@ final class MovieTitleInfoView: UIView {
     private func setupUI() {
         addSubview(titleLabel)
         addSubview(infoStackView)
-        addSubview(genreStackView)
+        addSubview(genreTagView)
 
         titleLabel.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -87,9 +71,9 @@ final class MovieTitleInfoView: UIView {
             make.leading.equalToSuperview()
         }
 
-        genreStackView.snp.makeConstraints { make in
+        genreTagView.snp.makeConstraints { make in
             make.top.equalTo(infoStackView.snp.bottom).offset(8)
-            make.leading.equalToSuperview()
+            make.leading.trailing.bottom.equalToSuperview()
         }
 
         dateStackView.addArrangedSubview(calendarImageView)
@@ -97,9 +81,6 @@ final class MovieTitleInfoView: UIView {
         
         infoStackView.addArrangedSubview(ratingLabel)
         infoStackView.addArrangedSubview(dateStackView)
-
-        genreStackView.addArrangedSubview(tagImageView)
-        genreStackView.addArrangedSubview(genreLabel)
     }
     
     func configure(title: String?, voteAverageText: String?, releaseDateText: String?, genres: [String]) {
@@ -116,10 +97,10 @@ final class MovieTitleInfoView: UIView {
         }
         
         if !genres.isEmpty {
-            genreLabel.text = genres.joined(separator: ", ")
-            genreStackView.isHidden = false
+            genreTagView.configure(genres: genres)
+            genreTagView.isHidden = false
         } else {
-            genreStackView.isHidden = true
+            genreTagView.isHidden = true
         }
     }
     

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
@@ -46,6 +46,24 @@ final class MovieTitleInfoView: UIView {
         return label
     }()
     
+    private let genreStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        return stack
+    }()
+    
+    private let tagImageView: UIImageView = {
+        let iv = UIImageView(image: UIImage(systemName: "tag"))
+        iv.tintColor = .gray
+        return iv
+    }()
+    
+    private let genreLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -58,24 +76,33 @@ final class MovieTitleInfoView: UIView {
     private func setupUI() {
         addSubview(titleLabel)
         addSubview(infoStackView)
-        
+        addSubview(genreStackView)
+
         titleLabel.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
         }
         
         infoStackView.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(8)
-            make.leading.bottom.equalToSuperview()
+            make.leading.equalToSuperview()
         }
-        
+
+        genreStackView.snp.makeConstraints { make in
+            make.top.equalTo(infoStackView.snp.bottom).offset(8)
+            make.leading.equalToSuperview()
+        }
+
         dateStackView.addArrangedSubview(calendarImageView)
         dateStackView.addArrangedSubview(dateLabel)
         
         infoStackView.addArrangedSubview(ratingLabel)
         infoStackView.addArrangedSubview(dateStackView)
+
+        genreStackView.addArrangedSubview(tagImageView)
+        genreStackView.addArrangedSubview(genreLabel)
     }
     
-    func configure(title: String?, voteAverageText: String?, releaseDateText: String?) {
+    func configure(title: String?, voteAverageText: String?, releaseDateText: String?, genres: [String]) {
         titleLabel.text = title
         
         ratingLabel.text = voteAverageText
@@ -87,5 +114,13 @@ final class MovieTitleInfoView: UIView {
         } else {
             dateStackView.isHidden = true
         }
+        
+        if !genres.isEmpty {
+            genreLabel.text = genres.joined(separator: ", ")
+            genreStackView.isHidden = false
+        } else {
+            genreStackView.isHidden = true
+        }
     }
+    
 }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTitleInfoView.swift
@@ -1,0 +1,91 @@
+//
+//  MovieTitleInfoView.swift
+//  MovieExplorer
+//
+
+import UIKit
+import SnapKit
+
+final class MovieTitleInfoView: UIView {
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title3)
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private let infoStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        return stack
+    }()
+    
+    private let ratingLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+    
+    private let dateStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        return stack
+    }()
+    
+    private let calendarImageView: UIImageView = {
+        let iv = UIImageView(image: UIImage(systemName: "calendar"))
+        iv.tintColor = .gray
+        return iv
+    }()
+    
+    private let dateLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        addSubview(titleLabel)
+        addSubview(infoStackView)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+        
+        infoStackView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(8)
+            make.leading.bottom.equalToSuperview()
+        }
+        
+        dateStackView.addArrangedSubview(calendarImageView)
+        dateStackView.addArrangedSubview(dateLabel)
+        
+        infoStackView.addArrangedSubview(ratingLabel)
+        infoStackView.addArrangedSubview(dateStackView)
+    }
+    
+    func configure(title: String?, voteAverageText: String?, releaseDateText: String?) {
+        titleLabel.text = title
+        
+        ratingLabel.text = voteAverageText
+        ratingLabel.isHidden = (voteAverageText == nil)
+        
+        if let date = releaseDateText {
+            dateLabel.text = date
+            dateStackView.isHidden = false
+        } else {
+            dateStackView.isHidden = true
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/MovieError+String.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieError+String.swift
@@ -1,0 +1,23 @@
+//
+//  MovieError+String.swift
+//  MovieExplorer
+//
+//  Created by Liam on 5/7/26.
+//
+
+extension MovieError {
+    var description: String {
+        switch self {
+        case .networkFailure:
+            return "네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요."
+        case .serverError:
+            return "서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+        case .invalidRequest:
+            return "잘못된 요청입니다."
+        case .decodingFailure:
+            return "데이터를 불러오는 중 오류가 발생했습니다."
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다."
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/PopularMovies/PopularMoviesViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/PopularMovies/PopularMoviesViewModel.swift
@@ -41,18 +41,7 @@ final class PopularMoviesViewModel {
             currentPage = nextPage
             totalPages = result.totalPages
         } catch let error as MovieError {
-            switch error {
-            case .networkFailure:
-                errorMessage = "네트워크 연결이 불안정합니다. 인터넷 연결을 확인해주세요."
-            case .serverError:
-                errorMessage = "서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
-            case .invalidRequest:
-                errorMessage = "잘못된 요청입니다."
-            case .decodingFailure:
-                errorMessage = "데이터를 불러오는 중 오류가 발생했습니다."
-            case .unknown:
-                errorMessage = "알 수 없는 오류가 발생했습니다."
-            }
+            errorMessage = error.description
         } catch {
             errorMessage = "예기치 못한 오류가 발생했습니다: \(error.localizedDescription)"
         }

--- a/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
@@ -183,7 +183,7 @@ final class DefaultMovieRepositoryTests: XCTestCase {
             title: "파이트 클럽",
             overview: "불면증에 시달리는 남자가...",
             posterPath: URL(string: "https://image.tmdb.org/t/p/w500/poster.jpg"),
-            backdropPath: URL(string: "https://image.tmdb.org/t/p/w500/backdrop.jpg"),
+            backdropPath: URL(string: "https://image.tmdb.org/t/p/w1280/backdrop.jpg"),
             releaseDate: "1999-10-15",
             runtime: 139,
             genres: ["드라마", "스릴러"],

--- a/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
@@ -1,0 +1,67 @@
+//
+//  GetMovieDetailUseCaseTests.swift
+//  MovieExplorerTests
+//
+//
+
+import XCTest
+@testable import MovieExplorer
+
+final class GetMovieDetailUseCaseTests: XCTestCase {
+    
+    var sut: DefaultGetMovieDetailUseCase!
+    var mockRepository: MockMovieRepository!
+    
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockMovieRepository()
+        sut = DefaultGetMovieDetailUseCase(movieRepository: mockRepository)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+    
+    func test_성공시_레포지토리의_결과를_그대로_반환한다() async throws {
+        // Given
+        let movieId = 550
+        let expectedDetail = MovieDetail(
+            id: movieId,
+            title: "파이트 클럽",
+            overview: "줄거리",
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: "1999-10-15",
+            runtime: 139,
+            genres: ["드라마"],
+            voteAverage: 8.4
+        )
+        mockRepository.mockDetailResult = .success(expectedDetail)
+        
+        // When
+        let result = try await sut.execute(id: movieId)
+        
+        // Then
+        XCTAssertEqual(mockRepository.fetchMovieDetailCallCount, 1)
+        XCTAssertEqual(mockRepository.lastRequestedId, movieId)
+        XCTAssertEqual(result, expectedDetail)
+    }
+    
+    func test_레포지토리에서_에러발생시_그대로_전달한다() async {
+        // Given
+        let movieId = 550
+        mockRepository.mockDetailResult = .failure(MovieError.networkFailure)
+        
+        // When & Then
+        do {
+            _ = try await sut.execute(id: movieId)
+            XCTFail("에러가 발생해야 하지만 성공했습니다.")
+        } catch let error as MovieError {
+            XCTAssertEqual(error, .networkFailure)
+        } catch {
+            XCTFail("예상치 못한 에러: \(error)")
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockGetMovieDetailUseCase.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockGetMovieDetailUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  MockGetMovieDetailUseCase.swift
+//  MovieExplorerTests
+//
+//
+
+import Foundation
+@testable import MovieExplorer
+
+final class MockGetMovieDetailUseCase: GetMovieDetailUseCase {
+    var mockResult: Result<MovieDetail, Error>?
+    var executeCallCount = 0
+    var lastRequestedId: Int?
+    
+    func execute(id: Int) async throws -> MovieDetail {
+        executeCallCount += 1
+        lastRequestedId = id
+        
+        if let result = mockResult {
+            switch result {
+            case .success(let detail): return detail
+            case .failure(let error): throw error
+            }
+        }
+        fatalError("mockResult not set")
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
@@ -9,9 +9,13 @@ import Foundation
 final class MockMovieRepository: MovieRepositoryProtocol {
     
     var mockResult: Result<(movies: [Movie], totalPages: Int), Error>?
+    var mockDetailResult: Result<MovieDetail, Error>?
     
     var fetchPopularMoviesCallCount = 0
     var lastRequestedPage: Int?
+    
+    var fetchMovieDetailCallCount = 0
+    var lastRequestedId: Int?
     
     func fetchPopularMovies(page: Int) async throws -> (movies: [Movie], totalPages: Int) {
         fetchPopularMoviesCallCount += 1
@@ -34,6 +38,18 @@ final class MockMovieRepository: MovieRepositoryProtocol {
     }
     
     func fetchMovieDetail(id: Int) async throws -> MovieDetail {
-        fatalError("Not needed for this test")
+        fetchMovieDetailCallCount += 1
+        lastRequestedId = id
+        
+        if let result = mockDetailResult {
+            switch result {
+            case .success(let detail):
+                return detail
+            case .failure(let error):
+                throw error
+            }
+        }
+        
+        fatalError("mockDetailResult is not set")
     }
 }

--- a/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
@@ -48,8 +48,8 @@ final class MovieDetailViewModelTests: XCTestCase {
         XCTAssertEqual(mockUseCase.executeCallCount, 1)
         XCTAssertEqual(mockUseCase.lastRequestedId, mockMovieId)
         XCTAssertEqual(sut.movieDetail, expectedDetail)
-        XCTAssertFalse(sut.isLoading)
-        XCTAssertNil(sut.errorMessage)
+        XCTAssertEqual(sut.state, .loaded)
+        XCTAssertEqual(sut.releaseDateText, "1999.10.15")
     }
     
     func test_에러발생시_errorMessage가_세팅된다() async {
@@ -60,8 +60,7 @@ final class MovieDetailViewModelTests: XCTestCase {
         await sut.fetchDetail()
         
         // Then
-        XCTAssertNotNil(sut.errorMessage)
-        XCTAssertFalse(sut.isLoading)
+        XCTAssertEqual(sut.state, .error(MovieError.networkFailure.description))
         XCTAssertNil(sut.movieDetail)
     }
 }

--- a/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
@@ -1,0 +1,67 @@
+//
+//  MovieDetailViewModelTests.swift
+//  MovieExplorerTests
+//
+//
+
+import XCTest
+@testable import MovieExplorer
+
+@MainActor
+final class MovieDetailViewModelTests: XCTestCase {
+    
+    var sut: MovieDetailViewModel!
+    var mockUseCase: MockGetMovieDetailUseCase!
+    let mockMovieId = 550
+    
+    override func setUp() {
+        super.setUp()
+        mockUseCase = MockGetMovieDetailUseCase()
+        sut = MovieDetailViewModel(movieId: mockMovieId, getMovieDetailUseCase: mockUseCase)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockUseCase = nil
+        super.tearDown()
+    }
+    
+    func test_정상적으로_상세정보를_가져온다() async {
+        // Given
+        let expectedDetail = MovieDetail(
+            id: mockMovieId,
+            title: "파이트 클럽",
+            overview: "줄거리",
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: "1999-10-15",
+            runtime: 139,
+            genres: ["드라마"],
+            voteAverage: 8.4
+        )
+        mockUseCase.mockResult = .success(expectedDetail)
+        
+        // When
+        await sut.fetchDetail()
+        
+        // Then
+        XCTAssertEqual(mockUseCase.executeCallCount, 1)
+        XCTAssertEqual(mockUseCase.lastRequestedId, mockMovieId)
+        XCTAssertEqual(sut.movieDetail, expectedDetail)
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertNil(sut.errorMessage)
+    }
+    
+    func test_에러발생시_errorMessage가_세팅된다() async {
+        // Given
+        mockUseCase.mockResult = .failure(MovieError.networkFailure)
+        
+        // When
+        await sut.fetchDetail()
+        
+        // Then
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertNil(sut.movieDetail)
+    }
+}


### PR DESCRIPTION
### GetMovieDetailUseCase
- 아키텍쳐 통일성을 위한 객체.
- 레포지토리 결과 반환, 에러 반환만을 테스트.

### MovieDetailViewModel
- 영화 하나에 대한 데이터를 출력에 맞게 가공하는 역할. 대부분 데이터는 도메인 데이터를 그대로 쓰지만 일부 데이터는 가공.
- 화면이 그려진 후 데이터가 변하지 않는 화면이므로 데이터 fetch가 끝났는지만 state로 두고 바인딩하여 뷰에게 전달할 수 있도록 함. 
- 에러에 대한 description을 다른 화면과 같이 쓸 수 있어 파일을 분리 후 코드 재사용.

### MovieDetailViewController
- Gradient View 적용 문제
  - 백드롭 이미지에 대한 명암 효과를 CAGradientLayer를 이용하여 구현.
  - CAGradientLayer는 오토레이아웃과 별개로 그려지기 때문에 그 높이를 동적으로 백드롭 이미지에 맞추기 위해서는 생명주기의 viewDidLayoutSubviews 시점에 높이를 주입하는 방식으로 해결.
- 파일의 크기가 커지는 문제, 미래의 확장성을 고려하여 제목과 영화 정보가 표시되는 부분을 MovieTitleInfoView로 분리하고, 그 중에서도 장르 표시 부분을 GenreTagView로 한 번 더 분리. 
  - GenreTagView는 컬렉션 뷰를 활용.
- 표시할 Backdrop 이미지가 기존 포스터 이미지 크기보다 크기 때문에 이에 따른 해상도 설정을 ImageURLMapper에서 변경. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a detailed movie information screen displaying title, rating, release date, and genres.
  * Genre tags now appear as visual indicators on the movie detail view.
  * Improved image display for movie backdrops with optimized sizing.

* **Bug Fixes**
  * Enhanced error messaging with localized, user-friendly descriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRJeon/Movie-Explorer/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->