### PR TITLE
[Feat] Video on detail view

### DIFF
--- a/MovieExplorer/MovieExplorer/Data/DTOs/MovieDetailResponseDTO.swift
+++ b/MovieExplorer/MovieExplorer/Data/DTOs/MovieDetailResponseDTO.swift
@@ -36,7 +36,8 @@ struct MovieDetailResponseDTO: Decodable {
             releaseDate: releaseDate,
             runtime: runtime,
             genres: genres.map { $0.name },
-            voteAverage: voteAverage
+            voteAverage: voteAverage,
+            youtubeKey: nil
         )
     }
 }

--- a/MovieExplorer/MovieExplorer/Data/DTOs/VideoResponseDTO.swift
+++ b/MovieExplorer/MovieExplorer/Data/DTOs/VideoResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  VideoResponseDTO.swift
+//  MovieExplorer
+//
+
+import Foundation
+
+struct VideoResponseDTO: Decodable {
+    let id: Int
+    let results: [VideoDTO]
+}
+
+struct VideoDTO: Decodable {
+    let key: String
+    let site: String
+    let type: String
+}

--- a/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
+++ b/MovieExplorer/MovieExplorer/Data/Network/MovieEndpoint.swift
@@ -11,6 +11,7 @@ enum MovieEndpoint: APIEndpoint {
     case popular(page: Int)
     case search(query: String, page: Int)
     case detail(id: Int)
+    case video(id: Int)
 
     private static let apiKey = APIKey.apiKey
 
@@ -26,6 +27,8 @@ enum MovieEndpoint: APIEndpoint {
             return "/3/search/movie"
         case .detail(let id):
             return "/3/movie/\(id)"
+        case .video(let id):
+            return "/3/movie/\(id)/videos"
         }
     }
 
@@ -56,6 +59,10 @@ enum MovieEndpoint: APIEndpoint {
         case .detail:
             return [
                 "language": "ko-KR"
+            ]
+        case .video:
+            return [
+                "language": "en-US"
             ]
         }
     }

--- a/MovieExplorer/MovieExplorer/Data/Repositories/DefaultMovieRepository.swift
+++ b/MovieExplorer/MovieExplorer/Data/Repositories/DefaultMovieRepository.swift
@@ -47,6 +47,17 @@ final class DefaultMovieRepository: MovieRepositoryProtocol {
         }
     }
 
+    func fetchYoutubeKey(id: Int) async throws -> String? {
+        do {
+            let endpoint = MovieEndpoint.video(id: id)
+            let response: VideoResponseDTO = try await networkService.request(endpoint: endpoint)
+            let trailer = response.results.first { $0.site == "YouTube" && $0.type == "Trailer" }
+            return trailer?.key
+        } catch {
+            throw mapError(error)
+        }
+    }
+
     private func mapError(_ error: Error) -> MovieError {
         if let movieError = error as? MovieError { return movieError }
         if error is URLError { return .networkFailure }

--- a/MovieExplorer/MovieExplorer/Domain/Entities/MovieDetail.swift
+++ b/MovieExplorer/MovieExplorer/Domain/Entities/MovieDetail.swift
@@ -17,4 +17,5 @@ nonisolated struct MovieDetail: Equatable {
     let runtime: Int?
     let genres: [String]
     let voteAverage: Double
+    let youtubeKey: String?
 }

--- a/MovieExplorer/MovieExplorer/Domain/Interfaces/MovieRepositoryProtocol.swift
+++ b/MovieExplorer/MovieExplorer/Domain/Interfaces/MovieRepositoryProtocol.swift
@@ -9,4 +9,5 @@ protocol MovieRepositoryProtocol {
     func fetchPopularMovies(page: Int) async throws -> (movies: [Movie], totalPages: Int)
     func searchMovies(query: String, page: Int) async throws -> (movies: [Movie], totalPages: Int)
     func fetchMovieDetail(id: Int) async throws -> MovieDetail
+    func fetchYoutubeKey(id: Int) async throws -> String?
 }

--- a/MovieExplorer/MovieExplorer/Domain/UseCases/GetMovieDetailUseCase.swift
+++ b/MovieExplorer/MovieExplorer/Domain/UseCases/GetMovieDetailUseCase.swift
@@ -14,6 +14,23 @@ struct DefaultGetMovieDetailUseCase: GetMovieDetailUseCase {
     let movieRepository: MovieRepositoryProtocol
 
     func execute(id: Int) async throws -> MovieDetail {
-        try await movieRepository.fetchMovieDetail(id: id)
+        async let fetchedDetail = movieRepository.fetchMovieDetail(id: id)
+        async let fetchedYoutubeKey = try? movieRepository.fetchYoutubeKey(id: id)
+
+        let detail = try await fetchedDetail
+        let youtubeKey = await fetchedYoutubeKey
+
+        return MovieDetail(
+            id: detail.id,
+            title: detail.title,
+            overview: detail.overview,
+            posterPath: detail.posterPath,
+            backdropPath: detail.backdropPath,
+            releaseDate: detail.releaseDate,
+            runtime: detail.runtime,
+            genres: detail.genres,
+            voteAverage: detail.voteAverage,
+            youtubeKey: youtubeKey
+        )
     }
 }

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -59,6 +59,8 @@ final class MovieDetailViewController: UIViewController {
         label.numberOfLines = 0
         return label
     }()
+
+    private let trailerView = MovieTrailerView()
     
     private let loadingIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .large)
@@ -94,12 +96,13 @@ final class MovieDetailViewController: UIViewController {
         view.backgroundColor = .systemBackground
         navigationController?.setNavigationBarHidden(false, animated: true)
 
-        view.addSubview(backdropImageView)
-        view.addSubview(gradientView)
-        applyGradient()
-
+        scrollView.contentInsetAdjustmentBehavior = .never
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
+
+        contentView.addSubview(backdropImageView)
+        contentView.addSubview(gradientView)
+        applyGradient()
 
         view.addSubview(loadingIndicator)
 
@@ -107,6 +110,7 @@ final class MovieDetailViewController: UIViewController {
         contentView.addSubview(titleInfoView)
         contentView.addSubview(overviewHeaderLabel)
         contentView.addSubview(overviewLabel)
+        contentView.addSubview(trailerView)
 
         backdropImageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -152,7 +156,13 @@ final class MovieDetailViewController: UIViewController {
             make.top.equalTo(overviewHeaderLabel.snp.bottom).offset(12)
             make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
             make.trailing.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(24)
+        }
+
+        trailerView.snp.makeConstraints { make in
+            make.top.equalTo(overviewLabel.snp.bottom).offset(40)
+            make.leading.equalTo(contentView.snp.trailing).multipliedBy(0.05)
+            make.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(40)
         }
     }
 
@@ -194,6 +204,8 @@ final class MovieDetailViewController: UIViewController {
             releaseDateText: viewModel.releaseDateText,
             genres: movie.genres
         )
+
+        trailerView.configure(with: movie.youtubeKey)
 
         if let url = viewModel.movieDetail?.backdropPath {
             backdropImageView.kf.setImage(with: url, options: [.transition(.fade(0.3))])

--- a/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTrailerView.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/MovieDetail/MovieTrailerView.swift
@@ -1,0 +1,107 @@
+//
+//  MovieTrailerView.swift
+//  MovieExplorer
+//
+
+import UIKit
+import WebKit
+import SnapKit
+
+final class MovieTrailerView: UIView {
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "예고편"
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        return label
+    }()
+    
+    private let webView: WKWebView = {
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.backgroundColor = .systemGray6
+        webView.layer.cornerRadius = 8
+        webView.clipsToBounds = true
+        webView.scrollView.isScrollEnabled = false
+        return webView
+    }()
+    
+    private lazy var youtubeButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.title = "YouTube에서 보기"
+        config.image = UIImage(systemName: "play.rectangle.fill")
+        config.imagePadding = 8
+        config.baseBackgroundColor = .systemRed
+        config.baseForegroundColor = .white
+        config.cornerStyle = .medium
+        
+        let button = UIButton(configuration: config)
+        button.addAction(UIAction { [weak self] _ in
+            self?.openYoutubeApp()
+        }, for: .touchUpInside)
+        return button
+    }()
+    
+    private var youtubeKey: String?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        addSubview(titleLabel)
+        addSubview(webView)
+        addSubview(youtubeButton)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+        
+        webView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(webView.snp.width).multipliedBy(9.0 / 16.0)
+        }
+        
+        youtubeButton.snp.makeConstraints { make in
+            make.top.equalTo(webView.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(44)
+            make.bottom.equalToSuperview()
+        }
+    }
+    
+    func configure(with youtubeKey: String?) {
+        guard let youtubeKey, !youtubeKey.isEmpty else {
+            isHidden = true
+            return
+        }
+        isHidden = false
+        self.youtubeKey = youtubeKey
+        
+        guard let url = URL(string: "https://www.youtube.com/embed/\(youtubeKey)?playsinline=1") else { return }
+
+        var request = URLRequest(url: url)
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.myApp.default"
+        request.setValue("https://\(bundleID)", forHTTPHeaderField: "Referer")
+
+        webView.load(request)
+    }
+    
+    private func openYoutubeApp() {
+        guard let key = youtubeKey else { return }
+        
+        if let appURL = URL(string: "youtube://\(key)"),
+           UIApplication.shared.canOpenURL(appURL) {
+            UIApplication.shared.open(appURL)
+        } else if let webURL = URL(string: "https://www.youtube.com/watch?v=\(key)") {
+            UIApplication.shared.open(webURL)
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
@@ -187,7 +187,8 @@ final class DefaultMovieRepositoryTests: XCTestCase {
             releaseDate: "1999-10-15",
             runtime: 139,
             genres: ["드라마", "스릴러"],
-            voteAverage: 8.4
+            voteAverage: 8.4,
+            youtubeKey: nil
         )
         XCTAssertEqual(result, expected)
     }

--- a/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
@@ -193,6 +193,66 @@ final class DefaultMovieRepositoryTests: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
+    // MARK: - fetchYoutubeKey
+
+    func test_fetchYoutubeKey_YouTube이면서_Trailer인_키값을_반환한다() async throws {
+        // given
+        let movieId = 123
+        let dto = VideoResponseDTO(
+            id: movieId,
+            results: [
+                VideoDTO(key: "key1", site: "Vimeo", type: "Trailer"),
+                VideoDTO(key: "key2", site: "YouTube", type: "Teaser"),
+                VideoDTO(key: "targetKey", site: "YouTube", type: "Trailer"),
+                VideoDTO(key: "key3", site: "YouTube", type: "Trailer")
+            ]
+        )
+        mockNetworkService.requestResult = dto
+
+        // when
+        let key = try await sut.fetchYoutubeKey(id: movieId)
+
+        // then
+        let endpoint = try XCTUnwrap(mockNetworkService.capturedEndpoint as? MovieEndpoint)
+        guard case .video(let capturedId) = endpoint else {
+            XCTFail("endpoint가 .video가 아닙니다")
+            return
+        }
+        XCTAssertEqual(capturedId, movieId)
+        XCTAssertEqual(key, "targetKey", "첫 번째 조건에 맞는 키를 반환해야 합니다")
+    }
+
+    func test_fetchYoutubeKey_조건에맞는_영상이_없으면_nil을_반환한다() async throws {
+        // given
+        let dto = VideoResponseDTO(
+            id: 123,
+            results: [
+                VideoDTO(key: "key1", site: "Vimeo", type: "Trailer"),
+                VideoDTO(key: "key2", site: "YouTube", type: "Teaser")
+            ]
+        )
+        mockNetworkService.requestResult = dto
+
+        // when
+        let key = try await sut.fetchYoutubeKey(id: 123)
+
+        // then
+        XCTAssertNil(key)
+    }
+
+    func test_fetchYoutubeKey_에러발생시_MovieError를_던진다() async {
+        // given
+        mockNetworkService.requestError = URLError(.notConnectedToInternet)
+
+        // when & then
+        do {
+            _ = try await sut.fetchYoutubeKey(id: 123)
+            XCTFail("에러가 발생해야 합니다")
+        } catch {
+            XCTAssertEqual(error as? MovieError, .networkFailure)
+        }
+    }
+
     // MARK: - Error Mapping
 
     func test_fetchPopularMovies_URLError발생시_networkFailure를_반환한다() async {

--- a/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
@@ -24,7 +24,48 @@ final class GetMovieDetailUseCaseTests: XCTestCase {
         super.tearDown()
     }
     
-    func test_성공시_레포지토리의_결과를_그대로_반환한다() async throws {
+    func test_성공시_레포지토리의_detail과_youtubeKey를_조합하여_반환한다() async throws {
+        // Given
+        let movieId = 550
+        let expectedDetail = MovieDetail(
+            id: movieId,
+            title: "파이트 클럽",
+            overview: "줄거리",
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: "1999-10-15",
+            runtime: 139,
+            genres: ["드라마"],
+            voteAverage: 8.4,
+            youtubeKey: nil // 초기값은 nil
+        )
+        mockRepository.mockDetailResult = .success(expectedDetail)
+        mockRepository.mockYoutubeKeyResult = .success("test_youtube_key")
+        
+        // When
+        let result = try await sut.execute(id: movieId)
+        
+        // Then
+        XCTAssertEqual(mockRepository.fetchMovieDetailCallCount, 1)
+        XCTAssertEqual(mockRepository.fetchYoutubeKeyCallCount, 1)
+        
+        let expectedFinalDetail = MovieDetail(
+            id: movieId,
+            title: "파이트 클럽",
+            overview: "줄거리",
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: "1999-10-15",
+            runtime: 139,
+            genres: ["드라마"],
+            voteAverage: 8.4,
+            youtubeKey: "test_youtube_key"
+        )
+        
+        XCTAssertEqual(result, expectedFinalDetail)
+    }
+    
+    func test_youtubeKey_조회에_실패하더라도_detail은_정상반환된다() async throws {
         // Given
         let movieId = 550
         let expectedDetail = MovieDetail(
@@ -40,20 +81,21 @@ final class GetMovieDetailUseCaseTests: XCTestCase {
             youtubeKey: nil
         )
         mockRepository.mockDetailResult = .success(expectedDetail)
+        mockRepository.mockYoutubeKeyResult = .failure(MovieError.networkFailure) // 키 발급 실패
         
         // When
         let result = try await sut.execute(id: movieId)
         
         // Then
-        XCTAssertEqual(mockRepository.fetchMovieDetailCallCount, 1)
-        XCTAssertEqual(mockRepository.lastRequestedId, movieId)
-        XCTAssertEqual(result, expectedDetail)
+        XCTAssertEqual(result.youtubeKey, nil)
+        XCTAssertEqual(result.title, "파이트 클럽")
     }
     
-    func test_레포지토리에서_에러발생시_그대로_전달한다() async {
+    func test_레포지토리에서_detail_조회에_에러발생시_그대로_전달한다() async {
         // Given
         let movieId = 550
         mockRepository.mockDetailResult = .failure(MovieError.networkFailure)
+        mockRepository.mockYoutubeKeyResult = .success("key")
         
         // When & Then
         do {

--- a/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Domain/GetMovieDetailUseCaseTests.swift
@@ -36,7 +36,8 @@ final class GetMovieDetailUseCaseTests: XCTestCase {
             releaseDate: "1999-10-15",
             runtime: 139,
             genres: ["드라마"],
-            voteAverage: 8.4
+            voteAverage: 8.4,
+            youtubeKey: nil
         )
         mockRepository.mockDetailResult = .success(expectedDetail)
         

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
@@ -53,7 +53,22 @@ final class MockMovieRepository: MovieRepositoryProtocol {
         fatalError("mockDetailResult is not set")
     }
 
+    var mockYoutubeKeyResult: Result<String?, Error>?
+    var fetchYoutubeKeyCallCount = 0
+    
     func fetchYoutubeKey(id: Int) async throws -> String? {
-        fatalError("Not needed for this test")
+        fetchYoutubeKeyCallCount += 1
+        lastRequestedId = id
+        
+        if let result = mockYoutubeKeyResult {
+            switch result {
+            case .success(let key):
+                return key
+            case .failure(let error):
+                throw error
+            }
+        }
+        
+        fatalError("mockYoutubeKeyResult is not set")
     }
 }

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
@@ -52,4 +52,8 @@ final class MockMovieRepository: MovieRepositoryProtocol {
         
         fatalError("mockDetailResult is not set")
     }
+
+    func fetchYoutubeKey(id: Int) async throws -> String? {
+        fatalError("Not needed for this test")
+    }
 }

--- a/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Presentation/MovieDetailViewModelTests.swift
@@ -37,7 +37,8 @@ final class MovieDetailViewModelTests: XCTestCase {
             releaseDate: "1999-10-15",
             runtime: 139,
             genres: ["드라마"],
-            voteAverage: 8.4
+            voteAverage: 8.4,
+            youtubeKey: nil
         )
         mockUseCase.mockResult = .success(expectedDetail)
         


### PR DESCRIPTION
### 💡 API 호출 책임: GetMovieDetailUsecase로 통합

**고민했던 선택지**
1. Usecase를 분리하여 ViewModel에서 각각 호출 (상세 정보 / 예고편 영상)
2. `GetMovieDetailUsecase` 내부에서 두 API를 모두 호출하고, 조합된 결과를 반환 (채택)

**고려 사항 및 결정 배경**
* **장단점 비교:** 1번 방식은 영상 API 결과가 늦게 오더라도 텍스트 화면을 먼저 그릴 수 있다는 장점이 있었습니다. 
* **아키텍처 관점 (채택 이유):** 하지만 동영상 키 값을 Presentation 레이어(ViewModel)에서 따로 상태로 들고 관리하기보다는, `MovieDetail`이라는 하나의 완성된 도메인 모델 안에서 관리하는 것이 계층 역할 분리에 더 맞다고 판단했습니다.
* **성능 타당성:** 영화 상세 정보 API와 Video API의 응답 시간 차이가 크지 않을 것으로 예상되므로, Usecase에서 두 데이터를 모두 fetch한 뒤 하나의 도메인 모델로 합쳐서 내려주는 것으로 최종 결정했습니다.

### 웹뷰 사용 중 트러블 슈팅
웹뷰를 사용하여 유튜브 영상을 임베드 하였으나 과정에서 몇 가지 트러블 슈팅을 겪었습니다.
- 스크롤 뷰 + 웹 뷰 조합에서 발생하는 무한 루프
  - 증상: 웹뷰를 추가하자 앱이 멈춤.
    - 가설: 스레드 문제 -> 화면의 다른 요소는 잘 그려지며 디버깅 결과 메인 스레드에서 코드가 돌아가고 있었음.
    - 가설2: 레이아웃 계산 충돌 -> 문제가 되는 웹뷰의 크기를 고정으로 두어도 문제가 해결되지 않음.
  - 추가 증상: 웹뷰의 크기를 작게 두어 스크롤이 필요하지 않은 크기가 되자 화면이 정상적으로 표출.
    - 가설: 스크롤뷰와 웹뷰의 레이아웃 계산 충돌
  - 결과 
    - 원인: 스크롤뷰의 contentInsetAdjustmentBehavior 동작으로 contentView가 조정되었을 때 웹뷰가 다시 그려지고, 이에 따라 레이아웃 갱신으로 인한 여백 검사가 다시 이루어지는 문제. 실제 크기의 변동이 없음에도 웹뷰는 외부 프로세스이기 때문에 같은 루프를 반복하는 것을 감지하지 못함.
    - 해결: scrollView.contentInsetAdjustmentBehavior = .never // 여백 검사를 하지 않음. contentView를 레이아웃 가이드에 맞게 그렸기 때문에 문제가 생길 가능성 낮음.
- 스크롤은 안 되고 스크롤 바만 줄어드는 현상
  - 원인: 뷰들 중 오토레이아웃 적용 시 스크롤 뷰의 컨텐츠 뷰 대신 상위 뷰에다 붙여버려 스크롤이 안 되는 컨텐츠들이 있었음.
  - 해결: 오토레이아웃을 컨텐츠 뷰를 기준으로 적용.
- 유튜브 오류 153: 동영상 플레이어 구성 오류
  - 원인: 유튜브 보안 정책
  - 해결: 앱 번들 ID를 Referer로 제공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie detail screens now display YouTube trailers directly within the app with an embedded player
  * Added a button to open full trailers on YouTube for seamless viewing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRJeon/Movie-Explorer/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->