### PR TITLE
[Feat] Search (description written by claude)

### DIFF
--- a/MovieExplorer/MovieExplorer/Data/DTOs/MovieResponseDTO.swift
+++ b/MovieExplorer/MovieExplorer/Data/DTOs/MovieResponseDTO.swift
@@ -23,11 +23,15 @@ struct MovieDTO: Decodable {
     let title: String
     let posterPath: String?
     let voteAverage: Double
+    let releaseDate: String?
+    let popularity: Double?
 
     enum CodingKeys: String, CodingKey {
         case id, title
         case posterPath = "poster_path"
         case voteAverage = "vote_average"
+        case releaseDate = "release_date"
+        case popularity
     }
 
     func toDomain() -> Movie {
@@ -36,6 +40,17 @@ struct MovieDTO: Decodable {
             title: title,
             posterPath: ImageURLMapper.makeFullPath(imagePath: posterPath),
             voteAverage: voteAverage
+        )
+    }
+
+    func toSearchResultDomain() -> SearchResult {
+        SearchResult(
+            id: id,
+            title: title,
+            posterPath: ImageURLMapper.makeFullPath(imagePath: posterPath),
+            releaseDate: releaseDate ?? "",
+            voteAverage: voteAverage,
+            popularity: popularity ?? 0.0
         )
     }
 }

--- a/MovieExplorer/MovieExplorer/Data/Repositories/DefaultMovieRepository.swift
+++ b/MovieExplorer/MovieExplorer/Data/Repositories/DefaultMovieRepository.swift
@@ -26,11 +26,11 @@ final class DefaultMovieRepository: MovieRepositoryProtocol {
         }
     }
 
-    func searchMovies(query: String, page: Int) async throws -> (movies: [Movie], totalPages: Int) {
+    func searchMovies(query: String, page: Int) async throws -> (movies: [SearchResult], totalPages: Int) {
         do {
             let endpoint = MovieEndpoint.search(query: query, page: page)
             let response: MovieResponseDTO = try await networkService.request(endpoint: endpoint)
-            let movies = response.results.map { $0.toDomain() }
+            let movies = response.results.map { $0.toSearchResultDomain() }
             return (movies: movies, totalPages: response.totalPages)
         } catch {
             throw mapError(error)

--- a/MovieExplorer/MovieExplorer/Domain/Entities/SearchResult.swift
+++ b/MovieExplorer/MovieExplorer/Domain/Entities/SearchResult.swift
@@ -1,0 +1,23 @@
+//
+//  SearchResult.swift
+//  MovieExplorer
+//
+//  Created by Liam on 5/13/26.
+//
+
+import Foundation
+
+nonisolated struct SearchResult: Equatable, Hashable {
+    let id: Int
+    let title: String
+    let posterPath: URL?
+    let releaseDate: String
+    let voteAverage: Double
+    let popularity: Double
+}
+
+extension SearchResult {
+    nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/MovieExplorer/MovieExplorer/Domain/Interfaces/MovieRepositoryProtocol.swift
+++ b/MovieExplorer/MovieExplorer/Domain/Interfaces/MovieRepositoryProtocol.swift
@@ -7,7 +7,7 @@
 
 protocol MovieRepositoryProtocol {
     func fetchPopularMovies(page: Int) async throws -> (movies: [Movie], totalPages: Int)
-    func searchMovies(query: String, page: Int) async throws -> (movies: [Movie], totalPages: Int)
+    func searchMovies(query: String, page: Int) async throws -> (movies: [SearchResult], totalPages: Int)
     func fetchMovieDetail(id: Int) async throws -> MovieDetail
     func fetchYoutubeKey(id: Int) async throws -> String?
 }

--- a/MovieExplorer/MovieExplorer/Domain/UseCases/SearchMoviesUseCase.swift
+++ b/MovieExplorer/MovieExplorer/Domain/UseCases/SearchMoviesUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  SearchMoviesUseCase.swift
+//  MovieExplorer
+//
+
+import Foundation
+
+protocol SearchMoviesUseCase {
+    func execute(query: String) async throws -> [SearchResult]
+}
+
+struct DefaultSearchMoviesUseCase: SearchMoviesUseCase {
+    
+    let movieRepository: MovieRepositoryProtocol
+    
+    func execute(query: String) async throws -> [SearchResult] {
+        var processedQuery = query
+        if let lastChar = processedQuery.last, 
+           let scalar = lastChar.unicodeScalars.first, 
+           (0x3131...0x318E).contains(scalar.value) {
+            processedQuery.removeLast()
+        }
+        
+        let trimmedQuery = processedQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedQuery.isEmpty else {
+            return []
+        }
+
+        let (movies, _) = try await movieRepository.searchMovies(query: trimmedQuery, page: 1)
+
+        return movies.sorted { $0.popularity > $1.popularity }
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/PopularMovies/PopularMoviesViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/PopularMovies/PopularMoviesViewController.swift
@@ -21,12 +21,25 @@ final class PopularMoviesViewController: UIViewController {
     }
 
     private let viewModel: PopularMoviesViewModel
+    private let searchViewModel: SearchMoviesViewModel
+    private lazy var searchResultsVC = SearchViewController(viewModel: searchViewModel)
+
     private var dataSource: UICollectionViewDiffableDataSource<Section, Movie>!
     private var cancellables = Set<AnyCancellable>()
     private var imagePrefetchers: [IndexPath: ImagePrefetcher] = [:]
-    
+
+    // MARK: - UI
+
     private lazy var topBarView: TopBarView = {
         return TopBarView(title: "Movie Explorer")
+    }()
+
+    private lazy var searchBar: UISearchBar = {
+        let bar = UISearchBar()
+        bar.placeholder = "영화를 검색해보세요"
+        bar.searchBarStyle = .minimal
+        bar.delegate = self
+        return bar
     }()
 
     private lazy var collectionView: UICollectionView = {
@@ -38,40 +51,54 @@ final class PopularMoviesViewController: UIViewController {
         cv.prefetchDataSource = self
         return cv
     }()
-    
-    init(viewModel: PopularMoviesViewModel) {
+
+    // MARK: - Init
+
+    init(viewModel: PopularMoviesViewModel, searchViewModel: SearchMoviesViewModel) {
         self.viewModel = viewModel
+        self.searchViewModel = searchViewModel
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    // MARK: - Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.setNavigationBarHidden(true, animated: false)
         setupUI()
+        setupSearchResultsChild()
         configureDataSource()
         bindViewModel()
-        
+
         Task {
             await viewModel.fetchNextPage()
         }
     }
-    
+
+    // MARK: - Setup
+
     private func setupUI() {
         view.backgroundColor = .systemBackground
         view.addSubview(topBarView)
+        view.addSubview(searchBar)
         view.addSubview(collectionView)
-        
+
         topBarView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
-        
-        collectionView.snp.makeConstraints { make in
+
+        searchBar.snp.makeConstraints { make in
             make.top.equalTo(topBarView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+        }
+
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(searchBar.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
 
@@ -104,9 +131,33 @@ final class PopularMoviesViewController: UIViewController {
         layoutButton.setImage(UIImage(systemName: "square.grid.2x2"), for: .normal)
         layoutButton.showsMenuAsPrimaryAction = true
         layoutButton.menu = menu
-        
+
         topBarView.setRightView(layoutButton)
     }
+
+    private func setupSearchResultsChild() {
+        addChild(searchResultsVC)
+        view.addSubview(searchResultsVC.view)
+        searchResultsVC.didMove(toParent: self)
+
+        searchResultsVC.view.snp.makeConstraints { make in
+            make.top.equalTo(searchBar.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+
+        searchResultsVC.view.isHidden = true
+    }
+
+    private func showSearchResults() {
+        view.bringSubviewToFront(searchResultsVC.view)
+        searchResultsVC.view.isHidden = false
+    }
+
+    private func hideSearchResults() {
+        searchResultsVC.view.isHidden = true
+    }
+
+    // MARK: - Layout
 
     private func changeLayout(columns: Int) {
         let visibleIndexPaths = collectionView.indexPathsForVisibleItems.sorted()
@@ -114,7 +165,6 @@ final class PopularMoviesViewController: UIViewController {
         let layout = createCompositionalLayout(columns: columns)
         collectionView.setCollectionViewLayout(layout, animated: true)
 
-        // 보던 item을 top으로 스크롤
         if let firstVisibleIndexPath {
             collectionView.scrollToItem(at: firstVisibleIndexPath, at: .top, animated: false)
         }
@@ -136,13 +186,15 @@ final class PopularMoviesViewController: UIViewController {
                 heightDimension: .absolute(groupHeight)
             )
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-            
+
             return NSCollectionLayoutSection(group: group)
         }
     }
-    
+
+    // MARK: - DataSource
+
     private func configureDataSource() {
-        dataSource = UICollectionViewDiffableDataSource<Section, Movie>(collectionView: collectionView) { (cv: UICollectionView, indexPath: IndexPath, movie: Movie) -> UICollectionViewCell? in
+        dataSource = UICollectionViewDiffableDataSource<Section, Movie>(collectionView: collectionView) { (cv, indexPath, movie) in
             guard let cell = cv.dequeueReusableCell(withReuseIdentifier: MovieCollectionViewCell.reuseIdentifier, for: indexPath) as? MovieCollectionViewCell else {
                 return UICollectionViewCell()
             }
@@ -150,7 +202,9 @@ final class PopularMoviesViewController: UIViewController {
             return cell
         }
     }
-    
+
+    // MARK: - Binding
+
     private func bindViewModel() {
         viewModel.$movies
             .receive(on: DispatchQueue.main)
@@ -161,7 +215,7 @@ final class PopularMoviesViewController: UIViewController {
                 self?.dataSource.apply(snapshot, animatingDifferences: true)
             }
             .store(in: &cancellables)
-            
+
         viewModel.$errorMessage
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
@@ -174,6 +228,32 @@ final class PopularMoviesViewController: UIViewController {
     }
 }
 
+// MARK: - UISearchBarDelegate
+extension PopularMoviesViewController: UISearchBarDelegate {
+
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(true, animated: true)
+        showSearchResults()
+    }
+
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        searchViewModel.updateSearchQuery(searchText)
+    }
+
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.text = ""
+        searchBar.setShowsCancelButton(false, animated: true)
+        searchBar.resignFirstResponder()
+        searchViewModel.clearSearchQuery()
+        hideSearchResults()
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
+}
+
+// MARK: - UICollectionViewDelegate
 extension PopularMoviesViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
@@ -187,6 +267,7 @@ extension PopularMoviesViewController: UICollectionViewDelegate {
     }
 }
 
+// MARK: - UICollectionViewDataSourcePrefetching
 extension PopularMoviesViewController: UICollectionViewDataSourcePrefetching {
 
     func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
@@ -200,7 +281,7 @@ extension PopularMoviesViewController: UICollectionViewDataSourcePrefetching {
             }
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cancelPrefetchingForItemsAt indexPaths: [IndexPath]) {
         for indexPath in indexPaths {
             imagePrefetchers[indexPath]?.stop()
@@ -218,8 +299,10 @@ struct PopularMoviesVC_Preview: PreviewProvider {
             let networkService = NetworkService()
             let repository = DefaultMovieRepository(networkService: networkService)
             let useCase = DefaultFetchPopularMoviesUseCase(movieRepository: repository)
+            let searchUseCase = DefaultSearchMoviesUseCase(movieRepository: repository)
             let viewModel = PopularMoviesViewModel(fetchPopularMoviesUseCase: useCase)
-            let vc = PopularMoviesViewController(viewModel: viewModel)
+            let searchViewModel = SearchMoviesViewModel(searchMoviesUseCase: searchUseCase)
+            let vc = PopularMoviesViewController(viewModel: viewModel, searchViewModel: searchViewModel)
             return UINavigationController(rootViewController: vc)
         }
     }

--- a/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchMoviesViewModel.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchMoviesViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  SearchMoviesViewModel.swift
+//  MovieExplorer
+//
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class SearchMoviesViewModel {
+    
+    @Published private(set) var searchResults: [SearchResult] = []
+    
+    private let searchMoviesUseCase: SearchMoviesUseCase
+    private var searchTask: Task<Void, Never>?
+    
+    private let searchQuerySubject = PassthroughSubject<String, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(searchMoviesUseCase: SearchMoviesUseCase) {
+        self.searchMoviesUseCase = searchMoviesUseCase
+        setupBindings()
+    }
+    
+    private func setupBindings() {
+        searchQuerySubject
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] query in
+                self?.performSearch(query: query)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func updateSearchQuery(_ query: String) {
+        searchQuerySubject.send(query)
+    }
+    
+    func clearSearchQuery() {
+        searchTask?.cancel()
+        searchResults = []
+        searchQuerySubject.send("")
+    }
+    
+    private func performSearch(query: String) {
+        searchTask?.cancel()
+        
+        guard !query.isEmpty else {
+            searchResults = []
+            return
+        }
+        
+        searchTask = Task {
+            do {
+                let results = try await searchMoviesUseCase.execute(query: query)
+                if !Task.isCancelled {
+                    self.searchResults = results
+                }
+            } catch {
+                if !Task.isCancelled {
+                    self.searchResults = []
+                }
+            }
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchResultCell.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchResultCell.swift
@@ -1,0 +1,100 @@
+//
+//  SearchResultCell.swift
+//  MovieExplorer
+//
+//
+
+import UIKit
+import SnapKit
+import Kingfisher
+
+final class SearchResultCell: UICollectionViewCell {
+    static let reuseIdentifier = "SearchResultCell"
+
+    private let posterImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .systemGray5
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 8
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15, weight: .semibold)
+        label.textColor = .label
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private let releaseDateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .regular)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+
+    private let ratingLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .medium)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+
+    private lazy var labelStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, releaseDateLabel, ratingLabel])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.alignment = .leading
+        return stack
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        posterImageView.kf.cancelDownloadTask()
+        posterImageView.image = nil
+        titleLabel.text = nil
+        releaseDateLabel.text = nil
+        ratingLabel.text = nil
+    }
+
+    private func setupUI() {
+        contentView.addSubview(posterImageView)
+        contentView.addSubview(labelStack)
+
+        posterImageView.snp.makeConstraints { make in
+            make.leading.top.bottom.equalToSuperview().inset(8)
+            make.width.equalTo(60)
+        }
+
+        labelStack.snp.makeConstraints { make in
+            make.leading.equalTo(posterImageView.snp.trailing).offset(12)
+            make.trailing.equalToSuperview().inset(12)
+            make.centerY.equalTo(posterImageView)
+        }
+    }
+
+    func configure(with result: SearchResult) {
+        titleLabel.text = result.title
+        releaseDateLabel.text = result.releaseDate.isEmpty ? nil : result.releaseDate
+        ratingLabel.text = "⭐ \(String(format: "%.1f", result.voteAverage))"
+
+        posterImageView.kf.setImage(
+            with: result.posterPath,
+            options: [
+                .transition(.fade(0.2)),
+                .cacheOriginalImage
+            ]
+        )
+    }
+}

--- a/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchResultCell.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchResultCell.swift
@@ -73,8 +73,12 @@ final class SearchResultCell: UICollectionViewCell {
         contentView.addSubview(labelStack)
 
         posterImageView.snp.makeConstraints { make in
-            make.leading.top.bottom.equalToSuperview().inset(8)
+            make.leading.equalToSuperview().inset(12)
+            make.centerY.equalToSuperview()
             make.width.equalTo(60)
+            make.height.equalTo(posterImageView.snp.width).multipliedBy(1.5)
+            make.top.greaterThanOrEqualToSuperview().inset(8)
+            make.bottom.lessThanOrEqualToSuperview().inset(8)
         }
 
         labelStack.snp.makeConstraints { make in

--- a/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchViewController.swift
+++ b/MovieExplorer/MovieExplorer/Presentation/SearchMovies/SearchViewController.swift
@@ -1,0 +1,145 @@
+//
+//  SearchViewController.swift
+//  MovieExplorer
+//
+//
+
+import UIKit
+import Combine
+import SnapKit
+
+final class SearchViewController: UIViewController {
+
+    nonisolated private enum Section: Hashable {
+        case main
+    }
+
+    private let viewModel: SearchMoviesViewModel
+    private var dataSource: UICollectionViewDiffableDataSource<Section, SearchResult>!
+    private var cancellables = Set<AnyCancellable>()
+
+    private lazy var collectionView: UICollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        cv.backgroundColor = .systemBackground
+        cv.register(SearchResultCell.self, forCellWithReuseIdentifier: SearchResultCell.reuseIdentifier)
+        cv.keyboardDismissMode = .onDrag
+        return cv
+    }()
+
+    private let emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "검색 결과가 없습니다"
+        label.textAlignment = .center
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.isHidden = true
+        return label
+    }()
+
+    private let placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "영화 제목을 검색해보세요"
+        label.textAlignment = .center
+        label.textColor = .tertiaryLabel
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        return label
+    }()
+
+    // MARK: - Init
+
+    init(viewModel: SearchMoviesViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        configureDataSource()
+        bindViewModel()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        view.addSubview(collectionView)
+        view.addSubview(emptyStateLabel)
+        view.addSubview(placeholderLabel)
+
+        collectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        emptyStateLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        placeholderLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(90)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(90)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+
+    private func configureDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<Section, SearchResult>(
+            collectionView: collectionView
+        ) { cv, indexPath, result in
+            guard let cell = cv.dequeueReusableCell(
+                withReuseIdentifier: SearchResultCell.reuseIdentifier,
+                for: indexPath
+            ) as? SearchResultCell else {
+                return UICollectionViewCell()
+            }
+            cell.configure(with: result)
+            return cell
+        }
+    }
+
+    // MARK: - Binding
+
+    private func bindViewModel() {
+        viewModel.$searchResults
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] results in
+                self?.applySnapshot(results)
+                self?.updateEmptyState(for: results)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func applySnapshot(_ results: [SearchResult]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, SearchResult>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(results, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+
+    private func updateEmptyState(for results: [SearchResult]) {
+        let hasQuery = !(viewModel.searchResults.isEmpty && results.isEmpty)
+        let isQueryActive = !results.isEmpty || hasQuery
+
+        placeholderLabel.isHidden = isQueryActive
+        emptyStateLabel.isHidden = !results.isEmpty || !isQueryActive
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
@@ -111,7 +111,7 @@ final class DefaultMovieRepositoryTests: XCTestCase {
             page: 1,
             totalPages: 3,
             results: [
-                MovieDTO(id: 10, title: "인터스텔라", posterPath: "/interstellar.jpg", voteAverage: 9.0, releaseDate: nil, popularity: nil)
+                MovieDTO(id: 10, title: "인터스텔라", posterPath: "/interstellar.jpg", voteAverage: 9.0, releaseDate: "2014-11-05", popularity: 123.4)
             ]
         )
         mockNetworkService.requestResult = dto
@@ -122,11 +122,13 @@ final class DefaultMovieRepositoryTests: XCTestCase {
         // then
         XCTAssertEqual(result.totalPages, 3)
         XCTAssertEqual(result.movies.count, 1)
-        let expectedMovie = Movie(id: 10, title: "인터스텔라", posterPath: URL(string: "https://image.tmdb.org/t/p/w500/interstellar.jpg"), voteAverage: 9.0)
+        let expectedMovie = SearchResult(id: 10, title: "인터스텔라", posterPath: URL(string: "https://image.tmdb.org/t/p/w500/interstellar.jpg"), releaseDate: "2014-11-05", voteAverage: 9.0, popularity: 123.4)
         XCTAssertEqual(result.movies[0].id, expectedMovie.id)
         XCTAssertEqual(result.movies[0].title, expectedMovie.title)
         XCTAssertEqual(result.movies[0].posterPath, expectedMovie.posterPath)
+        XCTAssertEqual(result.movies[0].releaseDate, expectedMovie.releaseDate)
         XCTAssertEqual(result.movies[0].voteAverage, expectedMovie.voteAverage)
+        XCTAssertEqual(result.movies[0].popularity, expectedMovie.popularity)
     }
 
 

--- a/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Data/DefaultMovieRepositoryTests.swift
@@ -54,8 +54,8 @@ final class DefaultMovieRepositoryTests: XCTestCase {
             page: 1,
             totalPages: 5,
             results: [
-                MovieDTO(id: 1, title: "영화1", posterPath: "/poster1.jpg", voteAverage: 8.5),
-                MovieDTO(id: 2, title: "영화2", posterPath: nil, voteAverage: 7.0)
+                MovieDTO(id: 1, title: "영화1", posterPath: "/poster1.jpg", voteAverage: 8.5, releaseDate: nil, popularity: nil),
+                MovieDTO(id: 2, title: "영화2", posterPath: nil, voteAverage: 7.0, releaseDate: nil, popularity: nil)
             ]
         )
         mockNetworkService.requestResult = dto
@@ -111,7 +111,7 @@ final class DefaultMovieRepositoryTests: XCTestCase {
             page: 1,
             totalPages: 3,
             results: [
-                MovieDTO(id: 10, title: "인터스텔라", posterPath: "/interstellar.jpg", voteAverage: 9.0)
+                MovieDTO(id: 10, title: "인터스텔라", posterPath: "/interstellar.jpg", voteAverage: 9.0, releaseDate: nil, popularity: nil)
             ]
         )
         mockNetworkService.requestResult = dto

--- a/MovieExplorer/MovieExplorerTests/Domain/SearchMoviesUseCaseTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Domain/SearchMoviesUseCaseTests.swift
@@ -1,0 +1,159 @@
+//
+//  SearchMoviesUseCaseTests.swift
+//  MovieExplorerTests
+//
+//
+
+import XCTest
+@testable import MovieExplorer
+
+final class SearchMoviesUseCaseTests: XCTestCase {
+
+    private var sut: DefaultSearchMoviesUseCase!
+    private var mockMovieRepository: MockMovieRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockMovieRepository = MockMovieRepository()
+        sut = DefaultSearchMoviesUseCase(movieRepository: mockMovieRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockMovieRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - 쿼리 필터링 테스트
+
+    func test_마지막글자가_미완성된_자음인경우_탈락시키고_요청한다() async throws {
+        // given
+        let query = "인터스텔ㄹ"
+        mockMovieRepository.mockSearchResult = .success((movies: [], totalPages: 1))
+        
+        // when
+        _ = try await sut.execute(query: query)
+        
+        // then
+        let capturedQuery = mockMovieRepository.lastRequestedQuery
+        XCTAssertEqual(capturedQuery, "인터스텔")
+    }
+    
+    func test_마지막글자가_미완성된_모음인경우_탈락시키고_요청한다() async throws {
+        // given
+        let query = "어벤져스ㅏ"
+        mockMovieRepository.mockSearchResult = .success((movies: [], totalPages: 1))
+        
+        // when
+        _ = try await sut.execute(query: query)
+        
+        // then
+        let capturedQuery = mockMovieRepository.lastRequestedQuery
+        XCTAssertEqual(capturedQuery, "어벤져스")
+    }
+
+    func test_미완성된문자가_아니면_원래_문자열그대로_요청한다() async throws {
+        // given
+        let query = "인터스텔라"
+        mockMovieRepository.mockSearchResult = .success((movies: [], totalPages: 1))
+        
+        // when
+        _ = try await sut.execute(query: query)
+        
+        // then
+        let capturedQuery = mockMovieRepository.lastRequestedQuery
+        XCTAssertEqual(capturedQuery, "인터스텔라")
+    }
+
+    // MARK: - 빈 문자열 테스트
+
+    func test_쿼리가_비어있을_경우_요청하지_않고_빈_배열을_반환한다() async throws {
+        // given
+        let query = ""
+        
+        // when
+        let result = try await sut.execute(query: query)
+        
+        // then
+        XCTAssertEqual(mockMovieRepository.searchMoviesCallCount, 0)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_공백만_있는_쿼리일_경우_요청하지_않고_빈_배열을_반환한다() async throws {
+        // given
+        let query = "   "
+        
+        // when
+        let result = try await sut.execute(query: query)
+        
+        // then
+        XCTAssertEqual(mockMovieRepository.searchMoviesCallCount, 0)
+        XCTAssertTrue(result.isEmpty)
+    }
+    
+    func test_미완성문자를_제거한_결과가_빈문자열이면_요청하지_않고_빈_배열을_반환한다() async throws {
+        // given
+        let query = "ㄱ"
+        
+        // when
+        let result = try await sut.execute(query: query)
+        
+        // then
+        XCTAssertEqual(mockMovieRepository.searchMoviesCallCount, 0)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Page 파라미터 테스트
+
+    func test_요청시_page는_항상_1로_고정된다() async throws {
+        // given
+        let query = "test"
+        mockMovieRepository.mockSearchResult = .success((movies: [], totalPages: 1))
+        
+        // when
+        _ = try await sut.execute(query: query)
+        
+        // then
+        XCTAssertEqual(mockMovieRepository.lastRequestedPage, 1)
+    }
+
+    // MARK: - 정렬 테스트
+
+    func test_반환되는_결과는_popularity를_기준으로_내림차순_정렬된다() async throws {
+        // given
+        let query = "영화"
+        let movies = [
+            SearchResult(id: 1, title: "영화1", posterPath: nil, releaseDate: "2020", voteAverage: 8.0, popularity: 10.5),
+            SearchResult(id: 2, title: "영화2", posterPath: nil, releaseDate: "2021", voteAverage: 7.0, popularity: 50.2),
+            SearchResult(id: 3, title: "영화3", posterPath: nil, releaseDate: "2022", voteAverage: 9.0, popularity: 3.1),
+            SearchResult(id: 4, title: "영화4", posterPath: nil, releaseDate: "2023", voteAverage: 6.0, popularity: 20.0)
+        ]
+        mockMovieRepository.mockSearchResult = .success((movies: movies, totalPages: 1))
+        
+        // when
+        let result = try await sut.execute(query: query)
+        
+        // then
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0].id, 2) // popularity: 50.2
+        XCTAssertEqual(result[1].id, 4) // popularity: 20.0
+        XCTAssertEqual(result[2].id, 1) // popularity: 10.5
+        XCTAssertEqual(result[3].id, 3) // popularity: 3.1
+    }
+
+    // MARK: - 에러 반환 테스트
+
+    func test_레포지토리에서_에러발생시_에러를_그대로_던진다() async {
+        // given
+        let query = "error"
+        mockMovieRepository.mockSearchResult = .failure(MovieError.networkFailure)
+        
+        // when & then
+        do {
+            _ = try await sut.execute(query: query)
+            XCTFail("에러가 던져져야 합니다")
+        } catch {
+            XCTAssertEqual(error as? MovieError, MovieError.networkFailure)
+        }
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Domain/SearchMoviesUseCaseTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Domain/SearchMoviesUseCaseTests.swift
@@ -65,6 +65,19 @@ final class SearchMoviesUseCaseTests: XCTestCase {
         XCTAssertEqual(capturedQuery, "인터스텔라")
     }
 
+    func test_문자열_양끝의_공백과_줄바꿈을_제거한_후_요청한다() async throws {
+        // given
+        let query = "   인터스텔라 \n"
+        mockMovieRepository.mockSearchResult = .success((movies: [], totalPages: 1))
+        
+        // when
+        _ = try await sut.execute(query: query)
+        
+        // then
+        let capturedQuery = mockMovieRepository.lastRequestedQuery
+        XCTAssertEqual(capturedQuery, "인터스텔라")
+    }
+
     // MARK: - 빈 문자열 테스트
 
     func test_쿼리가_비어있을_경우_요청하지_않고_빈_배열을_반환한다() async throws {

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
@@ -33,8 +33,25 @@ final class MockMovieRepository: MovieRepositoryProtocol {
         return ([], 0)
     }
     
+    var mockSearchResult: Result<(movies: [SearchResult], totalPages: Int), Error>?
+    var searchMoviesCallCount = 0
+    var lastRequestedQuery: String?
+
     func searchMovies(query: String, page: Int) async throws -> (movies: [SearchResult], totalPages: Int) {
-        fatalError("Not needed for this test")
+        searchMoviesCallCount += 1
+        lastRequestedQuery = query
+        lastRequestedPage = page
+        
+        if let result = mockSearchResult {
+            switch result {
+            case .success(let data):
+                return data
+            case .failure(let error):
+                throw error
+            }
+        }
+        
+        return ([], 0)
     }
     
     func fetchMovieDetail(id: Int) async throws -> MovieDetail {

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockMovieRepository.swift
@@ -33,7 +33,7 @@ final class MockMovieRepository: MovieRepositoryProtocol {
         return ([], 0)
     }
     
-    func searchMovies(query: String, page: Int) async throws -> (movies: [Movie], totalPages: Int) {
+    func searchMovies(query: String, page: Int) async throws -> (movies: [SearchResult], totalPages: Int) {
         fatalError("Not needed for this test")
     }
     

--- a/MovieExplorer/MovieExplorerTests/Mocks/MockSearchMoviesUseCase.swift
+++ b/MovieExplorer/MovieExplorerTests/Mocks/MockSearchMoviesUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  MockSearchMoviesUseCase.swift
+//  MovieExplorerTests
+//
+//
+
+import Foundation
+@testable import MovieExplorer
+
+final class MockSearchMoviesUseCase: SearchMoviesUseCase {
+    
+    var mockResult: Result<[SearchResult], Error>?
+    var executeCallCount = 0
+    var lastRequestedQuery: String?
+    
+    func execute(query: String) async throws -> [SearchResult] {
+        executeCallCount += 1
+        lastRequestedQuery = query
+        
+        if let result = mockResult {
+            switch result {
+            case .success(let data):
+                return data
+            case .failure(let error):
+                throw error
+            }
+        }
+        
+        return []
+    }
+}

--- a/MovieExplorer/MovieExplorerTests/Presentation/SearchMoviesViewModelTests.swift
+++ b/MovieExplorer/MovieExplorerTests/Presentation/SearchMoviesViewModelTests.swift
@@ -1,0 +1,108 @@
+//
+//  SearchMoviesViewModelTests.swift
+//  MovieExplorerTests
+//
+//
+
+import XCTest
+@testable import MovieExplorer
+
+@MainActor
+final class SearchMoviesViewModelTests: XCTestCase {
+    
+    private var sut: SearchMoviesViewModel!
+    private var mockUseCase: MockSearchMoviesUseCase!
+
+    override func setUp() {
+        super.setUp()
+        mockUseCase = MockSearchMoviesUseCase()
+        sut = SearchMoviesViewModel(searchMoviesUseCase: mockUseCase)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockUseCase = nil
+        super.tearDown()
+    }
+
+    // MARK: - 입력 및 디바운싱 테스트
+
+    func test_검색어를_입력하면_300ms_디바운싱_이후에_UseCase를_호출한다() async {
+        // given
+        mockUseCase.mockResult = .success([])
+
+        // when
+        sut.updateSearchQuery("인터")
+        sut.updateSearchQuery("인터스")
+        sut.updateSearchQuery("인터스텔라")
+        
+        // 300ms 보다 적게 기다리면 아직 호출되지 않아야 함
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(mockUseCase.executeCallCount, 0)
+        
+        // 300ms 이후에는 단 한 번만 호출되어야 함 (마지막 쿼리)
+        try? await Task.sleep(nanoseconds: 300_000_000) // 총 400ms 대기
+        XCTAssertEqual(mockUseCase.executeCallCount, 1)
+        XCTAssertEqual(mockUseCase.lastRequestedQuery, "인터스텔라")
+    }
+
+    func test_동일한_검색어가_연속으로_입력되면_removeDuplicates로_인해_중복요청을_방지한다() async {
+        // given
+        mockUseCase.mockResult = .success([])
+        
+        // when: 첫 번째 쿼리 입력
+        sut.updateSearchQuery("다크나이트")
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        let initialCallCount = mockUseCase.executeCallCount
+        
+        // when: 동일한 쿼리 다시 입력
+        sut.updateSearchQuery("다크나이트")
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        
+        // then: 호출 횟수가 증가하지 않아야 함
+        XCTAssertEqual(mockUseCase.executeCallCount, initialCallCount)
+    }
+
+    // MARK: - 검색 결과 제공 테스트
+
+    func test_UseCase에서_성공적으로_결과를_가져오면_searchResults를_업데이트한다() async {
+        // given
+        let expectedMovies = [
+            SearchResult(id: 1, title: "인터스텔라", posterPath: nil, releaseDate: "2014-11-05", voteAverage: 9.0, popularity: 120.0)
+        ]
+        mockUseCase.mockResult = .success(expectedMovies)
+        
+        // when
+        sut.updateSearchQuery("인터스텔라")
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        
+        // then
+        XCTAssertEqual(sut.searchResults.count, 1)
+        XCTAssertEqual(sut.searchResults.first?.title, "인터스텔라")
+    }
+
+    // MARK: - 쿼리 초기화 테스트
+
+    func test_쿼리를_지우면_디바운싱중인_요청이_취소되고_결과가_빈배열로_초기화된다() async {
+        // given
+        let expectedMovies = [SearchResult(id: 1, title: "인터스텔라", posterPath: nil, releaseDate: "2014", voteAverage: 9.0, popularity: 120.0)]
+        mockUseCase.mockResult = .success(expectedMovies)
+        
+        // 먼저 쿼리를 보내고 결과를 받음
+        sut.updateSearchQuery("인터스텔라")
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        XCTAssertEqual(sut.searchResults.count, 1)
+        
+        // when: 새로운 쿼리를 입력하고 디바운싱 중에 clear 호출
+        sut.updateSearchQuery("다크나이트")
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms 지남 (아직 디바운싱 중)
+        sut.clearSearchQuery() // 즉시 초기화 및 "" 전송
+        
+        // then: 취소되었으므로 "다크나이트"는 요청되지 않아야 함
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        // 첫 번째 "인터스텔라" 성공 후, clear()에 의한 ""가 ViewModel에서 차단됨
+        XCTAssertEqual(mockUseCase.executeCallCount, 1)
+        XCTAssertEqual(mockUseCase.lastRequestedQuery, "인터스텔라")
+        XCTAssertTrue(sut.searchResults.isEmpty)
+    }
+}


### PR DESCRIPTION
# [feat] 영화 검색 기능 구현

## 개요

TMDB 영화 검색 API를 연동하여 실시간 검색 기능을 구현했습니다.
Clean Architecture 레이어에 맞춰 Domain → Data → Presentation 순서로 작업했으며, 각 계층에 대한 Unit Test를 TDD 방식으로 작성했습니다.

---

## 주요 변경 사항

### Domain Layer

**`SearchResult.swift` (신규)**
- 인기 영화 목록의 `Movie`와 역할을 분리한 검색 전용 도메인 엔티티 추가
- `popularity` 및 `releaseDate` 필드를 포함하여 검색 결과 정렬 및 표시에 활용

**`SearchMoviesUseCase.swift` (신규)**
- `execute(query:)` 메서드 하나를 갖는 프로토콜과 기본 구현체(`DefaultSearchMoviesUseCase`) 추가
- 비즈니스 로직을 UseCase 내부에서 직접 처리:
  - 쿼리 마지막의 미완성 단일 자음/모음(`ㄱ`~`ㅎ`, `ㅏ`~`ㅣ`) 자동 제거
  - 앞뒤 공백 및 줄바꿈 제거 (`trimmingCharacters`)
  - 빈 쿼리인 경우 즉시 `[]` 반환 (네트워크 요청 없음)
  - 검색 결과를 `popularity` 기준 내림차순 정렬하여 반환

### Data Layer

**`MovieResponseDTO.swift` (수정)**
- 기존 `MovieDTO`에 `releaseDate`, `popularity` 프로퍼티 추가 (모두 Optional — 기존 인기 영화 API 호환 유지)
- `toSearchResultDomain()` 변환 메서드 추가 (`SearchResult`로 매핑)
- 별도 DTO 타입을 추가하지 않고 `MovieDTO` 하나로 통합하여 중복 제거

**`MovieRepositoryProtocol.swift` (수정)**
- `searchMovies(query:page:)` 반환 타입을 `[Movie]`에서 `[SearchResult]`로 변경

**`DefaultMovieRepository.swift` (수정)**
- `searchMovies` 구현에서 `.toSearchResultDomain()` 으로 매핑하도록 변경

### Presentation Layer

**`SearchMoviesViewModel.swift` (신규)**
- `@MainActor` 기반의 ViewModel
- Combine `PassthroughSubject` + `.debounce(300ms)` + `.removeDuplicates()` 파이프라인으로 디바운싱 구현
  - 타이핑 중 불필요한 네트워크 요청 방지
  - 동일한 쿼리가 연속으로 들어올 경우 중복 요청 차단
- `clearSearchQuery()`: 진행 중 Task 즉시 취소 + 결과 초기화 + 디바운싱 대기열 무효화

**`SearchViewController.swift` (신규)**
- `SearchMoviesViewModel`을 주입받아 `$searchResults`를 Combine으로 구독
- `UICollectionViewDiffableDataSource` 기반 리스트 뷰
- 세 가지 상태를 구분하여 표시:
  - **초기 상태**: "영화 제목을 검색해보세요" placeholder
  - **결과 있음**: 검색 결과 목록
  - **결과 없음**: "검색 결과가 없습니다" empty state

**`SearchResultCell.swift` (신규)**
- 검색 결과 표시용 가로형 셀 (포스터 썸네일 + 제목/개봉일/평점)
- 포스터 크기를 `width × 1.5` 고정 비율로 지정하여 셀 재사용 시 이미지 깨짐 방지

**`PopularMoviesViewController.swift` (수정)**
- `UISearchController` 대신 **일반 `UISearchBar`** 사용 (커스텀 TopBar와 레이아웃 충돌 방지)
- `SearchViewController`를 **Child ViewController**로 추가하여 CollectionView 위에 overlay로 배치
  - `isHidden` 토글로 검색 화면 표시/숨김 처리
  - `UISearchController`의 자동 present/dismiss 메커니즘 없이 완전한 레이아웃 제어권 확보
- `UISearchBarDelegate`를 통해 `SearchMoviesViewModel`에 쿼리 이벤트 전달

---

## 테스트

| 파일 | 케이스 수 | 검증 대상 |
|------|-----------|-----------|
| `SearchMoviesUseCaseTests.swift` | 9 | 자음/모음 탈락, 공백 트리밍, 빈 쿼리 무시, page 고정, popularity 정렬, 에러 전파 |
| `SearchMoviesViewModelTests.swift` | 4 | 300ms 디바운싱, removeDuplicates, 결과 바인딩, clearSearchQuery 동작 |
| `DefaultMovieRepositoryTests.swift` | 수정 | searchMovies 반환 타입 `SearchResult`로 업데이트 |
| `MockMovieRepository.swift` | 수정 | searchMovies Mock 구현 추가 |
| `MockSearchMoviesUseCase.swift` | 신규 | SearchMoviesUseCase Mock 추가 |

---

## 설계 결정 사항

**왜 `SearchResult`를 `Movie`와 분리했나요?**
검색 결과에서는 `popularity`, `releaseDate` 등 추가 정보가 필요하지만, 인기 영화 목록 API는 이 필드들을 내려주지 않거나 활용하지 않습니다. 역할을 분리하면 각 도메인 객체가 자신의 컨텍스트에 맞는 필드만 갖게 되어 의도가 명확해집니다.

**왜 `UISearchController` 대신 `UISearchBar`를 직접 사용했나요?**
`UISearchController`는 자신의 `searchBar`를 직접 소유하고 위치를 제어하기 때문에, `navigationItem` 없이 커스텀 레이아웃에 배치하면 활성화 시 레이아웃 제약이 충돌하여 SearchBar가 화면 밖으로 이탈하는 문제가 발생합니다. 일반 `UISearchBar` + `addChild` 방식으로 완전한 레이아웃 제어권을 가져왔습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added movie search functionality with a search bar integrated into the main screen
  * Search results display movie details including poster, title, release date, and rating
  * Results are automatically sorted by popularity for better discovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRJeon/Movie-Explorer/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->